### PR TITLE
Update install_deps.sh: python -> python3

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -24,4 +24,4 @@ else
 fi
 
 echo "Installing PyInstaller via pip..."
-python -m pip install pyinstaller
+python3 -m pip install pyinstaller


### PR DESCRIPTION
Ubuntu 24.04 LTS by default does not find `python`