### PR TITLE
Update build_and_install.sh: python -> python3

### DIFF
--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -1,4 +1,4 @@
 ./install_deps.sh
-python -m pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 python3 -m PyInstaller --onedir --name led_mon --add-data plugins:plugins --add-data snapshot_files:snapshot_files --add-data config.yaml:. --hidden-import=yaml --hidden-import=pynput --clean --noconfirm main.py
 ./install_service.sh


### PR DESCRIPTION
Ubuntu 24.04 LTS by default does not find `python`