### PR TITLE
Add standalone NixOS module modes and harden equalizer runtime

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -22,7 +22,7 @@ In `/home/tim/zaneyos/flake.nix`, add this as an input:
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     nix-flatpak.url = "github:gmodena/nix-flatpak?ref=latest";
     led-matrix-monitoring = {
-      url = "github:timoteuszelle/led-matrix/fix/robustness-and-permission-handling";
+      url = "github:timoteuszelle/led-matrix/main";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -49,6 +49,7 @@ In `$HOME/zaneyos/profiles/amd/default.nix`:
     ../../modules/drivers
     ../../modules/core
     inputs.led-matrix-monitoring.nixosModules.led-matrix-monitoring # Add this line
+    # or inputs.led-matrix-monitoring.nixosModules.ledmatrixmonitoring
   ];
   # Enable GPU Drivers
   drivers.amdgpu.enable = true;
@@ -86,19 +87,26 @@ Add the service configuration to `/home/tim/zaneyos/modules/core/services.nix`:
 # Add this to the existing services.nix file
 services.led-matrix-monitoring = {
   enable = true;
-  
-  # Configure what shows in each quadrant
-  topLeft = "cpu";
-  bottomLeft = "mem-bat";
-  topRight = "disk";
-  bottomRight = "net";
-  
+
+  # linuxOS | nix-flake | nix-module
+  configurationMode = "nix-module";
+
+  layout = {
+    duration = 10;
+    quadrants = {
+      topLeft = [{ name = "cpu"; }];
+      bottomLeft = [{ name = "mem-bat"; }];
+      topRight = [{ name = "disk"; }];
+      bottomRight = [{ name = "net"; }];
+    };
+  };
   # Optional: disable keyboard listener if you don't want Alt+I shortcut
   # disableKeyListener = true;
-  
   # Optional: disable plugins
   # disablePlugins = true;
-  
+
+  # Optional: environment override for display server access
+  # environment.DISPLAY = ":0";
   # Optional: run as a different user (default is root)
   # user = "tim";
 };
@@ -112,13 +120,18 @@ Create `$HOME/zaneyos/modules/core/led-matrix.nix`:
 {...}: {
   services.led-matrix-monitoring = {
     enable = true;
-    
-    # Configure what shows in each quadrant
-    topLeft = "cpu";
-    bottomLeft = "mem-bat";
-    topRight = "disk";
-    bottomRight = "net";
-    
+
+    configurationMode = "nix-module";
+
+    layout = {
+      duration = 10;
+      quadrants = {
+        topLeft = [{ name = "cpu"; }];
+        bottomLeft = [{ name = "mem-bat"; }];
+        topRight = [{ name = "disk"; }];
+        bottomRight = [{ name = "net"; }];
+      };
+    };
     # Optional settings
     # disableKeyListener = false;
     # disablePlugins = false;
@@ -146,14 +159,15 @@ Then add it to `$HOME/zaneyos/modules/core/default.nix`:
 
 ## Configuration Options
 
-The service supports these quadrant options:
-- `cpu`: CPU utilization
-- `net`: Network upload/download rates  
-- `disk`: Disk I/O rates
-- `mem-bat`: Memory utilization and battery status
-- `temp`: Temperature sensors
-- `fan`: Fan speeds
-- `none`: Disable quadrant
+Recommended options:
+- `configurationMode = "nix-module"` (or `nix-flake`)
+- `layout.duration`
+- `layout.quadrants.topLeft|bottomLeft|topRight|bottomRight`
+- each app item supports `name`, `duration`, `animate`, `scope`, `persistentDraw`, `disposeFn`, `display`, and `args`
+
+Compatibility options are still available:
+- `settings` / `config` / `configFile`
+- legacy shorthand `topLeft`, `bottomLeft`, `topRight`, `bottomRight`
 
 ## Building and Testing
 
@@ -182,7 +196,7 @@ After making the changes:
 
 ## User Permissions
 
-If you want to use the keyboard listener (Alt+I shortcut) and run as a non-root user, the service will automatically add your user to the `input` group. Consider the security implications of this.
+If you run as a non-root user and keep key listening enabled, the service adds the `input` supplementary group at service runtime. Consider the security implications of keyboard device access.
 
 ## Development
 

--- a/README-NIXOS.md
+++ b/README-NIXOS.md
@@ -1,237 +1,117 @@
 # Framework 16 LED Matrix Monitoring - NixOS Integration
 
-This repository provides a NixOS package and service for the Framework 16 LED Matrix System Monitor. It includes robustness improvements and easy NixOS integration.
+This repository provides a NixOS package and a standalone NixOS module (`ledmatrixmonitoring.nix`) for the Framework 16 LED Matrix monitor service.
 
-## Features
+## What is new in the module design
 
-- **Complete NixOS Integration**: Flake with module support for easy system integration
-- **Robust Error Handling**: Graceful degradation when hardware is unavailable or permissions are denied
-- **Configurable Service**: Systemd service with full configuration options
-- **Plugin Support**: Extensible plugin framework for additional functionality
-- **Framework Hardware Support**: Specifically designed for Framework 16 LED Matrix panels
+- **Standalone module file**: `ledmatrixmonitoring.nix` (no large inline module block in `flake.nix`)
+- **Nix-native configuration schema**: `services.led-matrix-monitoring.layout` (typed options for quadrants/apps)
+- **Configuration mode switch**: `configurationMode = "linuxOS" | "nix-flake" | "nix-module"`
+- **Backward compatibility**: legacy quadrant shorthand (`topLeft`, `bottomLeft`, etc.) and `settings`/`configFile` remain available
+- **Non-Nix Linux flow unchanged**: scripts like `build_and_install.sh` and `install_service.sh` are untouched
 
-## Quick Start
+## Quick start (flake-based NixOS)
 
-### Method 1: Direct Package Installation
-
-Add this to your NixOS configuration:
-
-```nix
-# configuration.nix or any imported module
-{ config, pkgs, ... }:
-
-let
-  led-matrix-monitoring = pkgs.callPackage (pkgs.fetchFromGitHub {
-    owner = "timoteuszelle";
-    repo = "led-matrix";
-    rev = "fix/robustness-and-permission-handling";  # Use latest commit hash
-    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";  # Replace with actual hash
-  } + "/default.nix") {};
-in
-{
-  environment.systemPackages = [ led-matrix-monitoring ];
-}
-```
-
-Then run manually:
-```bash
-led-matrix-monitor --help
-led-matrix-monitor --top-left cpu --bottom-left mem-bat --top-right disk --bottom-right net
-```
-
-### Method 2: Using Flakes (Recommended)
-
-#### Step 1: Add as flake input
-
-Add to your `flake.nix`:
+### 1) Add input
 
 ```nix
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    # ... your other inputs
     led-matrix-monitoring = {
-      url = "github:timoteuszelle/led-matrix/fix/robustness-and-permission-handling";
+      url = "github:timoteuszelle/led-matrix/main";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
-
-  outputs = { self, nixpkgs, led-matrix-monitoring, ... }:
-  {
-    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
-      system = "x86_64-linux";
-      modules = [
-        ./configuration.nix
-        led-matrix-monitoring.nixosModules.led-matrix-monitoring
-      ];
-    };
-  };
 }
 ```
 
-#### Step 2: Configure the service
-
-Add to your `configuration.nix`:
+### 2) Import the module
 
 ```nix
-{ config, lib, pkgs, ... }:
-
 {
-  # Enable the LED Matrix Monitoring service
+  imports = [
+    inputs.led-matrix-monitoring.nixosModules.led-matrix-monitoring
+    # or: inputs.led-matrix-monitoring.nixosModules.ledmatrixmonitoring
+  ];
+}
+```
+
+### 3) Configure the service (recommended style)
+
+```nix
+{
   services.led-matrix-monitoring = {
     enable = true;
-    
-    # Configure what shows in each quadrant
-    topLeft = "cpu";          # CPU utilization
-    bottomLeft = "mem-bat";   # Memory usage + battery status
-    topRight = "disk";        # Disk I/O rates
-    bottomRight = "net";      # Network upload/download
-    
-    # Optional: disable keyboard listener (Alt+I shortcut)
+    configurationMode = "nix-module";
+
+    layout = {
+      duration = 10;
+      quadrants = {
+        topLeft = [{ name = "cpu"; }];
+        bottomLeft = [{ name = "mem-bat"; }];
+        topRight = [{ name = "disk"; }];
+        bottomRight = [{ name = "net"; }];
+      };
+    };
+
+    # Optional examples:
     # disableKeyListener = true;
-    
-    # Optional: disable plugins
     # disablePlugins = true;
-    
-    # Optional: run as different user (default: root)
-    # user = "your-username";
+    # user = "tim";
+    # environment.DISPLAY = ":0";
   };
 }
 ```
 
-#### Step 3: Rebuild your system
+### 4) Rebuild
 
 ```bash
 sudo nixos-rebuild switch --flake .#your-hostname
 ```
 
-## Configuration Options
+## Configuration modes
 
-### Display Metrics
+- `linuxOS`
+  - Service behaves like normal Linux packaging lookup (no Nix-managed config file injected)
+  - Do **not** combine with `layout`, `settings`, `config`, `configFile`, or legacy quadrant shorthand
+- `nix-flake`
+  - Nix-managed config source required (`layout`, `settings`, `configFile`, or legacy shorthand)
+- `nix-module`
+  - Same runtime behavior as `nix-flake`, named for direct module-centric workflows
 
-Each quadrant can display:
-- `cpu`: CPU utilization percentage
-- `mem-bat`: Memory usage and battery charge/status
-- `disk`: Disk read/write I/O rates
-- `net`: Network upload/download rates
-- `temp`: Temperature sensor readings (plugin)
-- `fan`: Fan speed readings (plugin)
-- `none`: Disabled/blank
+## Configuration sources (priority and compatibility)
 
-### Service Options
+Recommended:
+- `layout` (typed, future-friendly Nix schema)
 
-```nix
-services.led-matrix-monitoring = {
-  enable = true;                    # Enable the service
-  topLeft = "cpu";                 # Top-left quadrant
-  bottomLeft = "mem-bat";          # Bottom-left quadrant
-  topRight = "disk";               # Top-right quadrant  
-  bottomRight = "net";             # Bottom-right quadrant
-  disableKeyListener = false;      # Disable Alt+I app identification
-  disablePlugins = false;          # Disable plugin system
-  user = "root";                   # User to run service as
-};
-```
+Also supported:
+- `settings` (raw attrset rendered to YAML)
+- `config` (deprecated alias of `settings`)
+- `configFile` (path to YAML file)
+- Legacy shorthand: `topLeft`, `bottomLeft`, `topRight`, `bottomRight` (+ `legacyDuration`)
 
-## Manual Usage
+## Notes for future development
 
-Run directly with custom options:
-
-```bash
-# Show help
-led-matrix-monitor --help
-
-# Custom configuration
-led-matrix-monitor \
-  --top-left cpu \
-  --bottom-left mem-bat \
-  --top-right temp \
-  --bottom-right fan \
-  --no-key-listener
-```
-
-## Keyboard Shortcuts
-
-- **Alt+I**: Display application names in each quadrant while pressed
-- Use `--no-key-listener` or `disableKeyListener = true` to disable
-
-## Permissions
-
-For keyboard functionality:
-- Service runs as `root` by default (recommended)
-- If running as user, they'll be added to `input` group automatically
-- Consider security implications of `input` group membership
+The new schema aligns with long-term roadmap goals:
+- clean mode boundaries
+- easier extension for additional app fields/options
+- stronger validation in module assertions
+- easier API-oriented evolution without forcing users to hand-maintain YAML-shaped config in Nix
 
 ## Troubleshooting
 
-### Check service status
+Check service status:
 ```bash
 systemctl status led-matrix-monitoring
 ```
 
-### View logs
+Follow logs:
 ```bash
 journalctl -u led-matrix-monitoring -f
 ```
 
-### Test without hardware
+Test binary:
 ```bash
-# Should show help even without LED matrices
 led-matrix-monitor --help
 ```
-
-### Common issues
-
-1. **"No LED devices found"**: LED Matrix panels not detected
-   - Check USB connections
-   - Verify Framework 16 with LED Matrix input modules
-
-2. **Permission errors**: Input device access denied
-   - Service automatically handles this when running as root
-   - For user mode, automatic `input` group membership is configured
-
-3. **Module import errors**: Missing dependencies
-   - All dependencies are automatically handled by Nix
-   - Try rebuilding: `nix build github:timoteuszelle/led-matrix/fix/robustness-and-permission-handling`
-
-## Development
-
-### Local development
-
-```bash
-git clone https://github.com/timoteuszelle/led-matrix.git
-cd led-matrix
-nix develop  # Enter development shell with all dependencies
-python led_system_monitor.py --help
-```
-
-### Building locally
-
-```bash
-nix build github:timoteuszelle/led-matrix/fix/robustness-and-permission-handling
-./result/bin/led-matrix-monitor --help
-```
-
-## Contributing
-
-This is a fork of the original [FW_LED_System_Monitor](https://code.karsttech.com/jeremy/FW_LED_System_Monitor.git) with NixOS packaging and robustness improvements.
-
-- Original upstream: MidnightJava/led-matrix  
-- NixOS integration: timoteuszelle/led-matrix
-
-Contributions welcome for:
-- Additional plugins
-- NixOS module improvements
-- Bug fixes and robustness improvements
-- Documentation updates
-
-## License
-
-MIT License (assuming - verify with original project)
-
-## Hardware Requirements
-
-- Framework 16 laptop
-- LED Matrix Input Module(s) installed
-- NixOS operating system
-

--- a/README-NIXOS.md
+++ b/README-NIXOS.md
@@ -91,6 +91,53 @@ Also supported:
 - `configFile` (path to YAML file)
 - Legacy shorthand: `topLeft`, `bottomLeft`, `topRight`, `bottomRight` (+ `legacyDuration`)
 
+## Module option reference
+
+Top-level options under `services.led-matrix-monitoring`:
+- `enable`
+  - Enables the systemd service and installs the package to `environment.systemPackages`.
+- `configurationMode`
+  - `linuxOS`: service runs without Nix-managed config injection and uses the app's Linux config lookup behavior.
+  - `nix-flake` / `nix-module`: require one Nix-managed config source (`layout`, `settings`, `config`, `configFile`, or full legacy quadrant shorthand).
+- `package`
+  - Package that provides `led-matrix-monitor`.
+- `layout`
+  - Recommended typed schema for quadrant/app configuration.
+- `settings` / `config`
+  - Raw YAML-like attrset (`config` is deprecated alias of `settings`).
+- `configFile`
+  - Existing YAML file path passed through `--config-file`.
+- Legacy shorthand options
+  - `topLeft`, `bottomLeft`, `topRight`, `bottomRight`, `legacyDuration`.
+- Runtime/service options
+  - `disableKeyListener`, `disablePlugins`, `user`, `group`, `environment`, `extraArguments`.
+
+`layout` app item options:
+- `name` (required)
+- `duration` (optional; falls back to layout duration)
+- `animate` (default `false`)
+- `scope` (optional; supports `panel` behavior)
+- `persistentDraw` (default `false`)
+- `disposeFn` (optional)
+- `display` (default `true`)
+- `args` (attrset of app-specific arguments)
+
+Validation rules enforced by module assertions:
+- `settings` and `config` cannot both be set.
+- `layout` is mutually exclusive with `settings`, `config`, `configFile`, and legacy shorthand.
+- `configFile` is mutually exclusive with `layout`, `settings`, `config`, and legacy shorthand.
+- Legacy shorthand requires all four quadrants to be set.
+- In `layout`, each quadrant list must contain at least one app.
+- In `linuxOS` mode, managed config sources are rejected.
+- In `nix-flake`/`nix-module` mode, one managed config source is required.
+
+## Panel-scope scheduling behavior
+
+- If an active app has `scope = "panel"`, it owns the full panel for that side while active.
+- The sibling quadrant on that side is suppressed for both rendering and app rotation during that active slice.
+- If both active top and bottom apps on the same panel request `scope = "panel"`, top quadrant app wins and a warning is logged.
+- For predictable behavior, configure one panel-scope app per side and set the sibling app to `display = false`.
+
 ## Notes for future development
 
 The new schema aligns with long-term roadmap goals:

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ systemctl status led-matrix-monitoring
 journalctl -u led-matrix-monitoring -f
 ```
 
+For a full module option reference (including `configurationMode`, config-source compatibility, runtime/service options, and layout app fields), see `README-NIXOS.md`.
+
 **Alternative: Systemd Service (Advanced)**
 
 For automated continuous execution, you can run as a systemd service instead:
@@ -272,8 +274,16 @@ Configure the following arguments in the config file (`app->args`)
 `fmt_24_hour: true|false`
 
 ### Weather (provided by `time_weather_plugin.py`):
-You must specify app arguments in the config file and set one or more environment variables, as described below.
+Specify app arguments in the config file as described below.
 Set arguments (`app -> ags`) for the `weather` app in the desired quadrant
+  - Weather provider behavior:
+    - Primary provider: OpenWeather (used when `OPENWEATHER_API_KEY` is set)
+    - Automatic fallback provider: Open-Meteo (no API key required)
+
+  - Environment variables:
+    - `OPENWEATHER_API_KEY` (optional): enables OpenWeather as primary provider.
+    - `IP_LOCATE_API_KEY` (optional): enables IPLocate-based IP geolocation when you do not set `lat_lon` or `zip_info`.
+      If this is not set, the app will fall back to keyless IP geolocation providers.
   - To enable online lookup of local weather information, the app must know your location. Choose one or more of the options.
 
     1) Specify country-specific zip and [ISO 3166 digraph code](https://www.iban.com/country-codes)
@@ -289,6 +299,8 @@ Set arguments (`app -> ags`) for the `weather` app in the desired quadrant
   - Display temperature in Celsius, Farenheit, or Kelinv. Default is metric
 
     `units: imperial|metric|standard`
+  - If weather is configured with `scope: panel`, it owns the full panel while active and the sibling quadrant on that side is suppressed by the scheduler.
+    For predictable rotation, configure one panel-scope app per side and set the sibling app to `display: false`.
   - Show current or forecast weather. Default is current
 
     `forecast: true|false`
@@ -325,6 +337,8 @@ Configure the following arguments in the config file (`app -> args`)
   `panel: left|right|<xxx>`
 
 ### Equalizer (provided by `equalizer_plugin.py`)
+The equalizer is effectively panel-wide per side (`left` or `right`) because it writes directly to the LED device for that side.
+If configured as `scope: panel`, the scheduler enforces panel ownership and suppresses the sibling quadrant while it is active.
 Set the following app settings. These are direct properties of the equalizer app, not args
 - Set to true if the app will handle drawing to the grid the entire time it is active. If false, the app draws a static snapshot on every invocation. Default is false
 

--- a/README.md
+++ b/README.md
@@ -351,9 +351,45 @@ Configure the following arguments in the config file (`app -> args`)
 - Use the internal python 9-band filter or use an extenal filter. [EasyEffects](https://github.com/wwmm/easyeffects) is the recommended external filter to use. You can tune the equalizer dynamically as it runs, using the EasyEffects GUI.
 
   `external-filter: false|true`
-- Identify device location by device or quandrant. Used for identifying the app instance if a dispose function is called
+- Select the equalizer input source mode.
+  - `playback` (default): follows the current sink monitor.
+  - `microphone`: captures microphone input (recommended to dedicate a panel/quadrant for this mode).
 
-  `side: left|right|<quadrant>`
+  `input-mode: playback|microphone`
+- Optional input device override used primarily with `input-mode: microphone` (matches an input device name).
+
+  `input-device: <device-name-or-index>`
+- Per-band gain multiplier applied after band energy detection.
+  - Default `1.35` for `playback` (improves low-volume responsiveness).
+  - Default `0.75` for `microphone` (reduces ambient mic sensitivity).
+
+  `level-gain: <float>`
+- Per-band minimum level threshold after gain. Bands below this value are forced to zero.
+  - Default `1` for `playback`.
+  - Default `18` for `microphone` (reduces ambient mic noise spikes).
+
+  `noise-gate-level: <int>`
+- Total level sum threshold used to treat frames as silent (for pulse idle transitions).
+  - Default `2` for `playback`.
+  - Default `48` for `microphone`.
+
+  `silence-level-sum-threshold: <int>`
+- Identify which physical panel side this equalizer instance controls. Used for instance identity/dispose handling.
+  Run playback and microphone equalizers as separate app instances and assign each to its own panel/quadrant time slice.
+
+  `side: left|right`
+- Delay (seconds) before entering pulse-only silent visuals when levels drop to zero.
+
+  `zero-frame-delay-sec: <seconds>`
+- Pulse start delay (legacy alias retained for compatibility). The lower of this and `zero-frame-delay-sec` is used.
+
+  `silent-pulse-after-sec: <seconds>`
+- Pulse period for long-silence mode (center-origin star-like ripple pulse).
+
+  `silent-pulse-period-sec: <seconds>`
+- Time for gradually revealing the inverted `EQ0` mask during long silence while pulsing.
+
+  `silent-pulse-reveal-sec: <seconds>`
 
 The equalizer relies on PulseAudio and Pipewire packages to receive and process the audio output of your computer. The following packages must be installed:
 - Debian/Ubuntu: `sudo apt install pipewire pipewire-pulse wireplumber pulseaudio-utils`

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ python -m led_mon.led_system_monitor
 ### For NixOS users:
 ```bash
 # Using the Nix flake (recommended)
-nix run github:MidnightJava/led-matrix
+nix run github:timoteuszelle/led-matrix/main
 
 # Or build locally
 nix build
@@ -96,77 +96,58 @@ nix build
 ```
 
 ### NixOS System Integration
+For NixOS users who want to run LED matrix monitoring as a system service, use the standalone module from this repository.
 
-For NixOS users who want to run LED matrix monitoring as a system service, additional configuration is required:
-
-**1. Add to your flake.nix inputs:**
+**1. Add flake input:**
 ```nix
 {
   inputs = {
     # ... other inputs
-    led-matrix-monitoring.url = "github:MidnightJava/led-matrix";
+    led-matrix-monitoring.url = "github:timoteuszelle/led-matrix/main";
   };
 }
 ```
 
-**2. Import the module in your NixOS configuration:**
+**2. Import module:**
 ```nix
 {
   imports = [
     inputs.led-matrix-monitoring.nixosModules.led-matrix-monitoring
+    # or: inputs.led-matrix-monitoring.nixosModules.ledmatrixmonitoring
   ];
 }
 ```
 
-**3. Enable and configure the service:**
+**3. Configure service (recommended Nix-native schema):**
 ```nix
 services.led-matrix-monitoring = {
   enable = true;
-  topLeft = "cpu";
-  bottomLeft = "mem-bat";
-  topRight = "disk";
-  bottomRight = "net";
-  disableKeyListener = true;  # Recommended for system service
-  user = "your-username";
+  configurationMode = "nix-module"; # linuxOS | nix-flake | nix-module
+
+  layout = {
+    duration = 10;
+    quadrants = {
+      topLeft = [{ name = "cpu"; }];
+      bottomLeft = [{ name = "mem-bat"; }];
+      topRight = [{ name = "disk"; }];
+      bottomRight = [{ name = "net"; }];
+    };
+  };
+
+  # Optional for graphical sessions:
+  # environment.DISPLAY = ":0";
 };
 ```
 
-**4. Add systemd service environment override (Required):**
-
-The service needs access to the display server. Add this to your NixOS configuration:
-
-```nix
-# Override the LED matrix monitoring service to add DISPLAY environment variable
-systemd.services.led-matrix-monitoring = {
-  environment = {
-    DISPLAY = ":0";  # Adjust if using different display
-  };
-  serviceConfig = {
-    # Ensure the service waits for the graphical session
-    After = [ "graphical-session.target" ];
-    Wants = [ "graphical-session.target" ];
-  };
-};
-```
-
-**5. Rebuild your system:**
+**4. Rebuild your system:**
 ```bash
 sudo nixos-rebuild switch
 ```
 
 **Troubleshooting NixOS Service Issues:**
-
-If the service fails to start with display connection errors:
-
 ```bash
-# Check service status
-systemctl --user status led-matrix-monitoring
-
-# View logs
-journalctl --user -u led-matrix-monitoring -f
-
-# Common error: "failed to acquire X connection: Bad display name"
-# Solution: Ensure DISPLAY environment variable is set in service override
+systemctl status led-matrix-monitoring
+journalctl -u led-matrix-monitoring -f
 ```
 
 **Alternative: Systemd Service (Advanced)**

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,9 +1,9 @@
 # Version Information
 
 ## Current Version
-- **Version**: 2.1.1
-- **Branch**: main
-- **Date**: 2026-02-20
+- **Version**: 2.1.2
+- **Branch**: pr/nixos-module-equalizer-hardening
+- **Date**: 2026-05-01
 
 ## Usage with specific commit
 
@@ -17,7 +17,16 @@ led-matrix-monitoring = {
 ```
 
 ## Changelog
-gn
+### v2.1.2 (2026-05-01)
+- **Equalizer stabilization and tuning**
+  - Removed intermediate EQ0 silence behavior in favor of pulse-only idle flow
+  - Improved playback/microphone mode defaults and noise-gate handling
+  - Reduced animation jitter and improved transition continuity under low/no input
+- **Runtime robustness**
+  - Fixed pulse rendering failure that could freeze silent-state updates
+  - Reduced cross-panel timing interference during persistent draw updates
+- **Nix module/config alignment**
+  - Kept Nix-native quadrant layout path documented and validated for runtime generation
 ### v2.1.1 (2026-03-01)
 - **Weather widget enhancements**
   - Support multiple weather measures (temp/condition, wind chill, wind speed/direction)

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,8 @@
 , python3
 , fetchFromGitHub
 , makeWrapper
+, inputmodule-control
+, pulseaudio
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -29,6 +31,7 @@ python3.pkgs.buildPythonApplication rec {
     scipy # Required for equalizer plugin
     sounddevice # Required for equalizer plugin
     pulsectl # Required for equalizer plugin
+    inputmodule-control # Required runtime binary for equalizer plugin LED output
     # Note: iplocate is not available in nixpkgs - time_weather_plugin will need to handle this gracefully
   ];
 
@@ -36,25 +39,26 @@ python3.pkgs.buildPythonApplication rec {
     mkdir -p $out/bin
     mkdir -p $out/lib/python${python3.pythonVersion}/site-packages
     mkdir -p $out/share/led-matrix
-    
+
     # Copy the entire led_mon module
     cp -r led_mon $out/lib/python${python3.pythonVersion}/site-packages/
-    
+
     # Note: time_weather_plugin is included - iplocate import is lazy-loaded inside a function,
     # so the plugin will work for zip/lat-lon lookups even without iplocate package.
     # IP-based location lookup will fail gracefully if iplocate is not available.
-    
+
     # Copy main.py to the package root
     cp main.py $out/lib/python${python3.pythonVersion}/site-packages/
-    
+
     # Copy example config and .env to share for reference
     cp led_mon/config.yaml $out/share/led-matrix/config.example.yaml
     cp .env-example $out/share/led-matrix/.env-example
-    
+
     # Create wrapper script with proper Python environment
     makeWrapper ${python3.withPackages (ps: with ps; [ pyserial numpy psutil evdev pynput pyyaml python-dotenv requests scipy sounddevice pulsectl ])}/bin/python $out/bin/led-matrix-monitor \
       --add-flags "$out/lib/python${python3.pythonVersion}/site-packages/main.py" \
-      --prefix PYTHONPATH : "$out/lib/python${python3.pythonVersion}/site-packages"
+      --prefix PYTHONPATH : "$out/lib/python${python3.pythonVersion}/site-packages" \
+      --prefix PATH : "${lib.makeBinPath [ inputmodule-control pulseaudio ]}"
   '';
 
   # Skip tests for now since there aren't any

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "led-matrix-monitoring";
-  version = "1.2.0-yaml";
+  version = "2.1.2";
   format = "other";
 
   src = ./.;

--- a/example-configuration.nix
+++ b/example-configuration.nix
@@ -6,31 +6,44 @@
 {
   # For flake users, add this to your flake.nix inputs:
   # led-matrix-monitoring = {
-  #   url = "github:timoteuszelle/led-matrix/fix/robustness-and-permission-handling";
+  #   url = "github:timoteuszelle/led-matrix/main";
   #   inputs.nixpkgs.follows = "nixpkgs";
   # };
-  # And add led-matrix-monitoring.nixosModules.led-matrix-monitoring to your modules list
+  # And add one of:
+  #   led-matrix-monitoring.nixosModules.led-matrix-monitoring
+  #   led-matrix-monitoring.nixosModules.ledmatrixmonitoring
+  # to your modules list.
 
   # Enable the LED Matrix Monitoring service
   services.led-matrix-monitoring = {
     enable = true;
-    
-    # Standard configuration
-    topLeft = "cpu";          # CPU usage in top-left
-    bottomLeft = "mem-bat";   # Memory + battery in bottom-left
-    topRight = "disk";        # Disk I/O in top-right
-    bottomRight = "net";      # Network traffic in bottom-right
-    
-    # Optional: Add temperature and fan monitoring
-    # topRight = "temp";
-    # bottomRight = "fan";
-    
+
+    # linuxOS | nix-flake | nix-module
+    configurationMode = "nix-module";
+
+    # Recommended: Nix-native config schema
+    layout = {
+      duration = 10;
+      quadrants = {
+        topLeft = [{ name = "cpu"; }];
+        bottomLeft = [{ name = "mem-bat"; }];
+        topRight = [{ name = "disk"; }];
+        bottomRight = [{ name = "net"; }];
+      };
+    };
+
+    # Legacy shorthand still works for compatibility:
+    # topLeft = "cpu";
+    # bottomLeft = "mem-bat";
+    # topRight = "disk";
+    # bottomRight = "net";
     # Optional: Disable keyboard shortcut (Alt+I)
     # disableKeyListener = true;
-    
     # Optional: Disable plugins
     # disablePlugins = true;
-    
+
+    # Optional: extra environment for graphical sessions
+    # environment.DISPLAY = ":0";
     # Optional: Run as specific user instead of root
     # user = "your-username";
   };

--- a/example-configuration.nix
+++ b/example-configuration.nix
@@ -32,6 +32,11 @@
       };
     };
 
+    # Panel-scope note:
+    # If an app is configured with scope = "panel", it owns the full panel for that side
+    # and the sibling quadrant is suppressed while active.
+    # If both top and bottom apps on a side are scope = "panel", top takes precedence.
+
     # Legacy shorthand still works for compatibility:
     # topLeft = "cpu";
     # bottomLeft = "mem-bat";

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
-
   outputs = { self, nixpkgs, flake-utils }:
+    let
+      nixosModule = import ./ledmatrixmonitoring.nix;
+    in
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -37,205 +39,11 @@
         };
       }
     ) // {
-      # NixOS module for system integration
-      nixosModules.led-matrix-monitoring = { config, lib, pkgs, ... }:
-        with lib;
-        let
-          cfg = config.services.led-matrix-monitoring;
-          led-matrix-monitoring = pkgs.callPackage ./default.nix {};
-
-          yamlFormat = pkgs.formats.yaml {};
-
-          # Helper to convert old-style config to YAML
-          # Note: 'app' key must be present (set to null) for the Python code to work
-          legacyToYaml = {
-            duration = 10;
-            quadrants = {
-              top-left = [{
-                app = null;  # Required by led_system_monitor.py
-                name = cfg.topLeft;
-                duration = 10;
-                animate = false;
-              }];
-              top-right = [{
-                app = null;
-                name = cfg.topRight;
-                duration = 10;
-                animate = false;
-              }];
-              bottom-left = [{
-                app = null;
-                name = cfg.bottomLeft;
-                duration = 10;
-                animate = false;
-              }];
-              bottom-right = [{
-                app = null;
-                name = cfg.bottomRight;
-                duration = 10;
-                animate = false;
-              }];
-            };
-          };
-
-          # Determine which config to use
-          configFile =
-            if cfg.configFile != null then cfg.configFile
-            else if cfg.config != null then yamlFormat.generate "led-matrix-config.yaml" cfg.config
-            else if cfg.topLeft != null then yamlFormat.generate "led-matrix-config.yaml" legacyToYaml
-            else throw "services.led-matrix-monitoring: either config, configFile, or legacy options must be set";
-        in {
-          options.services.led-matrix-monitoring = {
-            enable = mkEnableOption "LED Matrix Monitoring service";
-
-            config = mkOption {
-              type = types.nullOr yamlFormat.type;
-              default = null;
-              description = ''
-                Configuration for LED Matrix monitoring as a Nix attrset.
-                This will be converted to YAML. Mutually exclusive with configFile.
-
-                See example config.yaml in the package for the full schema.
-              '';
-              example = literalExpression ''
-                {
-                  duration = 10;
-                  quadrants = {
-                    top-left = [{
-                      app = {
-                        name = "cpu";
-                        duration = 10;
-                        animate = false;
-                      };
-                    }];
-                    bottom-left = [{
-                      app = {
-                        name = "mem-bat";
-                        duration = 10;
-                        animate = false;
-                      };
-                    }];
-                    top-right = [{
-                      app = {
-                        name = "disk";
-                        duration = 10;
-                        animate = false;
-                      };
-                    }];
-                    bottom-right = [{
-                      app = {
-                        name = "net";
-                        duration = 10;
-                        animate = false;
-                      };
-                    }];
-                  };
-                }
-              '';
-            };
-
-            configFile = mkOption {
-              type = types.nullOr types.path;
-              default = null;
-              description = ''
-                Path to YAML configuration file.
-                Mutually exclusive with config.
-              '';
-            };
-
-            # Legacy options for backward compatibility
-            topLeft = mkOption {
-              type = types.nullOr (types.enum [ "cpu" "net" "disk" "mem-bat" "none" "temp" "fan" ]);
-              default = null;
-              description = ''(DEPRECATED) Application to display on top-left quadrant. Use config or configFile instead.'';
-            };
-
-            bottomLeft = mkOption {
-              type = types.nullOr (types.enum [ "cpu" "net" "disk" "mem-bat" "none" "temp" "fan" ]);
-              default = null;
-              description = ''(DEPRECATED) Application to display on bottom-left quadrant. Use config or configFile instead.'';
-            };
-
-            topRight = mkOption {
-              type = types.nullOr (types.enum [ "cpu" "net" "disk" "mem-bat" "none" "temp" "fan" ]);
-              default = null;
-              description = ''(DEPRECATED) Application to display on top-right quadrant. Use config or configFile instead.'';
-            };
-
-            bottomRight = mkOption {
-              type = types.nullOr (types.enum [ "cpu" "net" "disk" "mem-bat" "none" "temp" "fan" ]);
-              default = null;
-              description = ''(DEPRECATED) Application to display on bottom-right quadrant. Use config or configFile instead.'';
-            };
-
-            disableKeyListener = mkOption {
-              type = types.bool;
-              default = false;
-              description = "Disable keyboard shortcut listener";
-            };
-
-            disablePlugins = mkOption {
-              type = types.bool;
-              default = false;
-              description = "Disable plugin system";
-            };
-
-            user = mkOption {
-              type = types.str;
-              default = "root";
-              description = "User to run the service as";
-            };
-          };
-
-          config = mkIf cfg.enable {
-            # Validation
-            assertions = [
-              {
-                assertion = (cfg.config == null) || (cfg.configFile == null);
-                message = "services.led-matrix-monitoring: config and configFile are mutually exclusive";
-              }
-              {
-                assertion = (cfg.config != null) || (cfg.configFile != null) || (cfg.topLeft != null);
-                message = "services.led-matrix-monitoring: either config, configFile, or legacy options must be set";
-              }
-            ];
-
-            environment.systemPackages = [ led-matrix-monitoring ];
-
-            systemd.services.led-matrix-monitoring = {
-              description = "Framework LED Matrix System Monitor";
-              wantedBy = [ "multi-user.target" ];
-              after = [ "network.target" ];
-
-              serviceConfig = {
-                Type = "simple";
-                User = cfg.user;
-                Group = if cfg.user == "root" then "root" else "users";
-                Restart = "always";
-                RestartSec = "10s";
-              };
-
-              environment = {
-                # Point to the generated or provided config file
-                CONFIG_FILE = configFile;
-              };
-
-              script = let
-                args = lib.concatStringsSep " " (
-                  lib.optionals cfg.disableKeyListener [ "--no-key-listener" ]
-                  ++ lib.optionals cfg.disablePlugins [ "--disable-plugins" ]
-                );
-              in ''
-                ${led-matrix-monitoring}/bin/led-matrix-monitor ${args}
-              '';
-            };
-
-            # Add user to input group if key listener is enabled and not running as root
-            users.users = mkIf (!cfg.disableKeyListener && cfg.user != "root") {
-              ${cfg.user}.extraGroups = [ "input" ];
-            };
-          };
-        };
+      nixosModules = {
+        default = nixosModule;
+        led-matrix-monitoring = nixosModule;
+        ledmatrixmonitoring = nixosModule;
+      };
     };
 }
 

--- a/led_mon/config-README.md
+++ b/led_mon/config-README.md
@@ -10,7 +10,7 @@ Here is an explanation of the parameters that can (or must) be specified for eac
 
 **duration** (optional): The number of seconds the app will be displayed before switching to the next one. If there is only one app in the quadrant, this parameter will have no effect. This paramater is optional only if a global `duration` value is specified.
 
-**scope** (optional): If set to `panel`, the app will be displayed on the entire panel instead of a single quandrant. The other quadrant on the panel should have an app with `display:false` for the same duration, to avoid a conflict. For single-quadrant display, omit this parameter, set it to any other value, or specify no value.
+**scope** (optional): If set to `panel`, the app will be displayed on the entire panel instead of a single quandrant. The scheduler now enforces panel ownership: while a panel-scope app is active in either quadrant, the sibling quadrant on that side is suppressed for rendering and app rotation. If both top and bottom apps on the same side are active and both set `scope: panel`, the top quadrant app takes precedence and a warning is logged. For predictable behavior, configure one panel-scope app per side and set the sibling quadrant app to `display:false`.
 
 **animate** (optional): If set to true, the displayed pattern will scroll vertically.
 

--- a/led_mon/config.yaml
+++ b/led_mon/config.yaml
@@ -22,7 +22,21 @@ quadrants:
     persistent-draw: true
     args:
       external-filter: false
-      # left|right|<name of quadrant>
+      # playback|microphone
+      input-mode: playback
+      # Optional input device override for microphone mode (substring match)
+      # input-device: "Microphone"
+      # Level shaping (defaults: playback gain=1.35 gate=1 sum-threshold=2,
+      # microphone gain=0.75 gate=18 sum-threshold=48)
+      # level-gain: 1.35
+      # noise-gate-level: 1
+      # silence-level-sum-threshold: 2
+      # Silence behavior tuning (continuous center-origin star pulse)
+      # zero-frame-delay-sec: 4  # pulse-only silence display delay
+      # silent-pulse-after-sec: 12
+      # silent-pulse-period-sec: 3.8
+      # silent-pulse-reveal-sec: 5
+      # left|right
       side: left
       border: false  
   - app:
@@ -64,6 +78,11 @@ quadrants:
     persistent-draw: true
     args:
       external-filter: false
+      # Optional overrides:
+      # input-mode: microphone
+      # level-gain: 0.75
+      # noise-gate-level: 18
+      # silence-level-sum-threshold: 48
       side: right
       border: false
   - app:

--- a/led_mon/equalizer_files/visualize.py
+++ b/led_mon/equalizer_files/visualize.py
@@ -59,8 +59,13 @@ UPDATE_RATE = 0.03 # 33 fps
 # 9 frequency bands (If you use an EasyEffects filter, match the centers as closely as possible)
 BAND_CENTERS = [31.5, 63, 125, 250, 500, 1000, 2000, 4000, 8000]  # Hz
 Q = 1.414
+INPUTMODULE_CONTROL_APP = shutil.which('inputmodule-control')
+# Backward-compatible alias
+MODUE_CONTROL_APP = INPUTMODULE_CONTROL_APP
+PACTL_APP = shutil.which('pactl')
 
-MODUE_CONTROL_APP = shutil.which('inputmodule-control')
+def has_inputmodule_control():
+    return bool(INPUTMODULE_CONTROL_APP and Path(INPUTMODULE_CONTROL_APP).is_file())
 
 # Pre-compute bandpass filters (used in python file mode)
 filters = []
@@ -104,11 +109,13 @@ def get_notification_pattern(source):
         return 'gradient'
     
 def draw_source_change_cue(source):
+    if not has_inputmodule_control():
+        return
     pattern = get_notification_pattern(source)
     devices= discover_led_devices()
     # Only one instance will usually detect the source change, so it notifies both devices
     cmd_1 = [
-            MODUE_CONTROL_APP,
+            INPUTMODULE_CONTROL_APP,
             '--serial-dev', devices[0][1],
             'led-matrix',
             '--pattern',
@@ -116,7 +123,7 @@ def draw_source_change_cue(source):
     ]
     if len(devices) > 1:
         cmd_2 = [
-                MODUE_CONTROL_APP,
+                INPUTMODULE_CONTROL_APP,
                 '--serial-dev', devices[1][1],
                 'led-matrix',
                 '--pattern',
@@ -144,19 +151,27 @@ class Equalizer():
     
     def __init__(self, device_location):
         self.done = False
+        self.device_name = None
         self.queue = queue.Queue(2)
         self.drawing_thread = DrawingThread(device_location, self.queue)
         self.drawing_thread.start()
         
     def stop(self):
-        self.done = True
-        self.queue.put(None)  # Sentinel to stop DrawingThread
-        log.debug(f"Stop equalizer on device {self.device_name}")
+        if not self.done:
+            self.done = True
+            self.queue.put(None)  # Sentinel to stop DrawingThread
+        device_name = self.device_name if self.device_name else "<unknown>"
+        log.debug(f"Stop equalizer on device {device_name}")
     
     # Pipewire is supposed to automatically make the default source track the default sink's monitor, but the
     # capability is fragile and can sometimes be permanently broken. So we track sink changes and set the default
     # source to its monitor, to ensure continued data flow. We also draw a visual cue identifying the new source.
     def force_monitor_source(self):
+        if not PACTL_APP:
+            if not hasattr(self, '_pactl_missing_logged'):
+                self._pactl_missing_logged = True
+                log.warning("pactl was not found on PATH; skipping monitor-source auto-sync for equalizer.")
+            return
         last_known_sink = None
         try:
             current_sink = get_default_device(DeviceType.SINK)
@@ -172,7 +187,7 @@ class Equalizer():
             if current_source != expected_source and current_source is not None:
                 log.info(f"New sink detected: {current_sink}")
                 subprocess.run(
-                    ['pactl', 'set-default-source', expected_source],
+                    [PACTL_APP, 'set-default-source', expected_source],
                     check=True,
                     capture_output=True,
                     text=True
@@ -203,10 +218,11 @@ class Equalizer():
         self.queue.put((grid, False))
 
     def run(self, channel, external_filter, device_name):
-        if not MODUE_CONTROL_APP or not Path(MODUE_CONTROL_APP).is_file():
-            log.error("The executable file inputmodule-control was not found on the executable Path. The equalizer will not run.")
-            return
         self.device_name = device_name
+        if not has_inputmodule_control():
+            log.error("The executable file inputmodule-control was not found on the executable Path. The equalizer will not run.")
+            self.stop()
+            return False
         global base_time
         base_time = time.time()
         
@@ -239,7 +255,7 @@ class Equalizer():
                         levels.append(level)
 
                 cmd = [
-                    MODUE_CONTROL_APP,
+                    INPUTMODULE_CONTROL_APP,
                     '--serial-dev', device_name,
                     'led-matrix',
                     '--eq',
@@ -275,6 +291,7 @@ class Equalizer():
                 self.cleanup()
             finally:
                 self.stream = None
+        return True
             
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="LED Matrix Audio Visualizer - Single Channel")

--- a/led_mon/equalizer_files/visualize.py
+++ b/led_mon/equalizer_files/visualize.py
@@ -48,8 +48,10 @@ class DeviceType(Enum):
     SINK = 2
 
 SOURCE_CHECK_INTERVAL_SEC = 1
-
-ZERO_FRAME_NOTIFY_DELAY_SEC = 2
+DEFAULT_ZERO_FRAME_NOTIFY_DELAY_SEC = 4.0
+DEFAULT_SILENT_PULSE_AFTER_SEC = 12.0
+DEFAULT_SILENT_PULSE_PERIOD_SEC = 3.8
+DEFAULT_SILENT_PULSE_REVEAL_SEC = 5.0
 
 # Configuration
 SAMPLE_RATE = 48000
@@ -80,19 +82,60 @@ def scale_rms(rms, min_db=-60, max_db=0):
     db = 20 * np.log10(rms + 1e-10)
     normalized = np.clip((db - min_db) / (max_db - min_db), 0, 1)
     return int(normalized * 34)
+def clamp_positive_float(value, default):
+    try:
+        parsed = float(value)
+        return parsed if parsed > 0 else float(default)
+    except (TypeError, ValueError):
+        return float(default)
+
+def clamp_nonnegative_int(value, default):
+    try:
+        parsed = int(value)
+        return parsed if parsed >= 0 else int(default)
+    except (TypeError, ValueError):
+        return int(default)
+def resolve_input_stream_device(input_mode, input_device_hint=None):
+    if input_device_hint:
+        return input_device_hint
+    if input_mode != 'microphone':
+        return 'default'
+    try:
+        devices = sd.query_devices()
+        input_devices = [d for d in devices if int(d.get('max_input_channels', 0)) > 0]
+        non_monitor_devices = [
+            d for d in input_devices
+            if 'monitor' not in str(d.get('name', '')).lower()
+        ]
+        preferred = [
+            d for d in non_monitor_devices
+            if any(
+                token in str(d.get('name', '')).lower()
+                for token in ('mic', 'microphone', 'capture', 'input')
+            )
+        ]
+        selected = preferred[0] if preferred else (non_monitor_devices[0] if non_monitor_devices else None)
+        if selected:
+            selected_name = selected.get('name')
+            log.info(f"Using microphone input device: {selected_name}")
+            return selected_name
+    except Exception as e:
+        log.warning(f"Could not auto-select microphone input device: {e}")
+    return 'default'
 
 
-
-# Shared audio buffer and lock
-audio_buffer = np.zeros((CHUNK_SIZE, 2), dtype=np.float32)
-buffer_lock = threading.Lock()
 # Lock for writing to LED matrix device
 device_lock = threading.Lock()
+_device_write_locks = {}
+_device_write_locks_guard = threading.Lock()
 
-def audio_callback(indata, frames, time_info, status):
-    global audio_buffer
-    with buffer_lock:
-        audio_buffer = indata.copy()
+def get_device_write_lock(device_name):
+    with _device_write_locks_guard:
+        lock = _device_write_locks.get(device_name)
+        if lock is None:
+            lock = threading.Lock()
+            _device_write_locks[device_name] = lock
+        return lock
 
 def get_notification_pattern(source):
     if re.match(".*headphone.*|.*Audio_Expansion.*", source):
@@ -152,6 +195,9 @@ class Equalizer():
     def __init__(self, device_location):
         self.done = False
         self.device_name = None
+        self.last_known_sink = None
+        self.audio_buffer = np.zeros((CHUNK_SIZE, 2), dtype=np.float32)
+        self.buffer_lock = threading.Lock()
         self.queue = queue.Queue(2)
         self.drawing_thread = DrawingThread(device_location, self.queue)
         self.drawing_thread.start()
@@ -159,9 +205,33 @@ class Equalizer():
     def stop(self):
         if not self.done:
             self.done = True
-            self.queue.put(None)  # Sentinel to stop DrawingThread
+            try:
+                self.queue.put_nowait(None)  # Sentinel to stop DrawingThread
+            except queue.Full:
+                try:
+                    self.queue.get_nowait()
+                except queue.Empty:
+                    pass
+                try:
+                    self.queue.put_nowait(None)
+                except queue.Full:
+                    pass
         device_name = self.device_name if self.device_name else "<unknown>"
         log.debug(f"Stop equalizer on device {device_name}")
+
+    def queue_frame(self, grid, animate=False):
+        frame = (grid, animate)
+        try:
+            self.queue.put_nowait(frame)
+        except queue.Full:
+            try:
+                self.queue.get_nowait()
+            except queue.Empty:
+                pass
+            try:
+                self.queue.put_nowait(frame)
+            except queue.Full:
+                pass
     
     # Pipewire is supposed to automatically make the default source track the default sink's monitor, but the
     # capability is fragile and can sometimes be permanently broken. So we track sink changes and set the default
@@ -172,11 +242,9 @@ class Equalizer():
                 self._pactl_missing_logged = True
                 log.warning("pactl was not found on PATH; skipping monitor-source auto-sync for equalizer.")
             return
-        last_known_sink = None
         try:
             current_sink = get_default_device(DeviceType.SINK)
-
-            if current_sink == last_known_sink or current_sink is None:
+            if current_sink == self.last_known_sink or current_sink is None:
                 if not self.done:
                     Timer(SOURCE_CHECK_INTERVAL_SEC, self.force_monitor_source).start()
                 return
@@ -200,7 +268,7 @@ class Equalizer():
                 else:
                     log.warning(f"Failed to change default source: still {verified}")
                     
-            last_known_sink = current_sink
+            self.last_known_sink = current_sink
 
         except subprocess.CalledProcessError as e:
             log.error(f"Failed to check/fix default source: {e}")
@@ -211,26 +279,163 @@ class Equalizer():
         
     def cleanup(self, sig=None, frame=None):
         self.stop()
+
+    def audio_callback(self, indata, frames, time_info, status):
+        if status:
+            log.debug(f"Audio callback status ({self.device_name or 'unknown'}): {status}")
+        with self.buffer_lock:
+            self.audio_buffer = indata.copy()
         
     def draw_id(self, device_name):
         grid = np.zeros((9,34), dtype = int)
         grid[:,:] = id_patterns['equalizer_paused'] * shared_state.foreground_value
-        self.queue.put((grid, False))
+        self.queue_frame(grid, False)
+    def draw_inverted_silence_pulse(self, elapsed_sec, pulse_period_sec, reveal_sec):
+        pulse_period_sec = clamp_positive_float(pulse_period_sec, DEFAULT_SILENT_PULSE_PERIOD_SEC)
+        reveal_sec = clamp_positive_float(reveal_sec, DEFAULT_SILENT_PULSE_REVEAL_SEC)
+        base_foreground = max(1, int(shared_state.foreground_value))
+        phase = (elapsed_sec / pulse_period_sec) % 1.0
+        # Triangle wave avoids the visual "pause" at min/max that a sinusoid can create.
+        wave = 1.0 - abs((2.0 * phase) - 1.0)
 
-    def run(self, channel, external_filter, device_name):
+        x = np.arange(9, dtype=float)[:, None]
+        y = np.arange(34, dtype=float)[None, :]
+        center_x = 4.0
+        center_y = 16.5
+        norm_x = (x - center_x) / 4.0
+        norm_y = (y - center_y) / 16.5
+        radial = np.sqrt((norm_x ** 2) + (norm_y ** 2))
+        angle = np.arctan2(norm_y, norm_x)
+
+        # Warp radial distance into a star-like contour.
+        star_scale = 1.0 + (0.28 * np.cos(4.0 * angle))
+        star_radius = radial / np.clip(star_scale, 0.45, None)
+        pulse_radius = 0.22 + (1.20 * wave)
+        shell_width = 0.11
+        shell = np.exp(-((star_radius - pulse_radius) ** 2) / (2.0 * (shell_width ** 2)))
+        fill = np.clip((pulse_radius - star_radius) / max(pulse_radius, 1e-6), 0.0, 1.0)
+        shape = np.clip((0.50 * fill) + (0.50 * shell), 0.0, 1.0)
+
+        brightness = 0.30 + (0.70 * wave)
+        grid = np.rint(np.clip(base_foreground * shape * brightness, 0, 255)).astype(int)
+        grid = np.where(shape > 0.04, np.maximum(grid, 1), grid)
+
+        reveal = np.clip(elapsed_sec / reveal_sec, 0.0, 1.0)
+        paused_mask = (id_patterns['equalizer_paused'] > 0).astype(float)
+        grid = np.rint(grid * (1.0 - (paused_mask * reveal))).astype(int)
+        self.queue_frame(grid, False)
+
+    def run(
+        self,
+        channel,
+        external_filter,
+        device_name,
+        input_mode='playback',
+        input_device=None,
+        level_gain=1.0,
+        noise_gate_level=0,
+        silence_level_sum_threshold=0,
+        zero_frame_notify_delay_sec=DEFAULT_ZERO_FRAME_NOTIFY_DELAY_SEC,
+        silent_pulse_after_sec=DEFAULT_SILENT_PULSE_AFTER_SEC,
+        silent_pulse_period_sec=DEFAULT_SILENT_PULSE_PERIOD_SEC,
+        silent_pulse_reveal_sec=DEFAULT_SILENT_PULSE_REVEAL_SEC,
+    ):
         self.device_name = device_name
         if not has_inputmodule_control():
             log.error("The executable file inputmodule-control was not found on the executable Path. The equalizer will not run.")
             self.stop()
             return False
-        global base_time
-        base_time = time.time()
+
+        input_mode = str(input_mode or 'playback').strip().lower()
+        if input_mode not in ('playback', 'microphone'):
+            log.warning(f"Unknown equalizer input mode '{input_mode}', defaulting to playback.")
+            input_mode = 'playback'
+
+        zero_frame_notify_delay_sec = max(
+            0.0,
+            clamp_positive_float(zero_frame_notify_delay_sec, DEFAULT_ZERO_FRAME_NOTIFY_DELAY_SEC)
+        )
+        legacy_silent_pulse_after_sec = clamp_positive_float(silent_pulse_after_sec, DEFAULT_SILENT_PULSE_AFTER_SEC)
+        silent_pulse_after_sec = min(zero_frame_notify_delay_sec, legacy_silent_pulse_after_sec)
+        silent_pulse_period_sec = clamp_positive_float(silent_pulse_period_sec, DEFAULT_SILENT_PULSE_PERIOD_SEC)
+        silent_pulse_reveal_sec = clamp_positive_float(silent_pulse_reveal_sec, DEFAULT_SILENT_PULSE_REVEAL_SEC)
+        level_gain = max(0.1, clamp_positive_float(level_gain, 1.0))
+        noise_gate_level = min(34, clamp_nonnegative_int(noise_gate_level, 0))
+        silence_level_sum_threshold = clamp_nonnegative_int(silence_level_sum_threshold, 0)
+        if input_mode == 'playback':
+            activity_resume_threshold = max(18, silence_level_sum_threshold + 10)
+            activity_resume_hold_sec = 0.45
+        else:
+            activity_resume_threshold = max(26, silence_level_sum_threshold + 12)
+            activity_resume_hold_sec = 0.30
+
+        if input_mode == 'playback':
+            self.force_monitor_source()
+        device_write_lock = get_device_write_lock(device_name)
+
+        stream_device = resolve_input_stream_device(input_mode, input_device)
+        stream_channels = 2
+        try:
+            if stream_device != 'default':
+                device_info = sd.query_devices(stream_device, 'input')
+                stream_channels = 2 if int(device_info.get('max_input_channels', 1)) >= 2 else 1
+            elif input_mode == 'microphone':
+                default_info = sd.query_devices(kind='input')
+                stream_channels = 2 if int(default_info.get('max_input_channels', 1)) >= 2 else 1
+        except Exception as e:
+            log.warning(f"Could not query input channels for '{stream_device}', falling back to mono: {e}")
+            stream_channels = 1
+
+        def make_stream(selected_device, channels):
+            return sd.InputStream(
+                samplerate=SAMPLE_RATE,
+                channels=channels,
+                blocksize=CHUNK_SIZE,
+                callback=self.audio_callback,
+                device=selected_device
+            )
+
+        try:
+            stream = make_stream(stream_device, stream_channels)
+        except Exception as e:
+            if stream_device != 'default':
+                log.warning(f"Unable to open input device '{stream_device}', retrying with default input: {e}")
+                stream_device = 'default'
+                stream_channels = 2 if input_mode == 'playback' else 1
+                stream = make_stream(stream_device, stream_channels)
+            else:
+                log.error(f"Unable to open equalizer input stream: {e}")
+                self.stop()
+                return False
+
+        last_nonzero_frame_ts = time.monotonic()
+        pulse_phase_anchor_ts = last_nonzero_frame_ts
+        idle_mode = None
+        idle_mode_started_ts = None
+        active_candidate_started_ts = None
         
         def update_leds():
-            global event_queue, current_source, base_time
+            nonlocal last_nonzero_frame_ts, pulse_phase_anchor_ts, idle_mode, idle_mode_started_ts, active_candidate_started_ts
+
+            def render_silent_pulse(now):
+                nonlocal idle_mode, idle_mode_started_ts
+                if idle_mode != 'silent-pulse':
+                    idle_mode = 'silent-pulse'
+                    idle_mode_started_ts = now
+                pulse_elapsed = now - pulse_phase_anchor_ts
+                self.draw_inverted_silence_pulse(
+                    elapsed_sec=pulse_elapsed,
+                    pulse_period_sec=silent_pulse_period_sec,
+                    reveal_sec=silent_pulse_reveal_sec,
+                )
             while not self.done:
-                with buffer_lock:
-                    chunk = audio_buffer[:, channel]  # extract left or right channel only
+                with self.buffer_lock:
+                    buffer_snapshot = self.audio_buffer.copy()
+                if buffer_snapshot.ndim == 1:
+                    chunk = buffer_snapshot
+                else:
+                    selected_channel = min(channel, max(0, buffer_snapshot.shape[1] - 1))
+                    chunk = buffer_snapshot[:, selected_channel]
 
                 levels = []
 
@@ -253,6 +458,8 @@ class Equalizer():
                         rms = np.sqrt(np.mean(filtered ** 2))
                         level = scale_rms(rms)
                         levels.append(level)
+                boosted_levels = [min(34, int(round(level * level_gain))) for level in levels]
+                levels = [0 if level < noise_gate_level else level for level in boosted_levels]
 
                 cmd = [
                     INPUTMODULE_CONTROL_APP,
@@ -260,37 +467,55 @@ class Equalizer():
                     'led-matrix',
                     '--eq',
                 ] + [str(l) for l in levels]
-                # print(f"{device_name} {levels}")
-                with device_lock:
-                    if not shared_state.id_key_press_active:
-                        if sum(levels) == 0 and time.time() - base_time > ZERO_FRAME_NOTIFY_DELAY_SEC:
-                            self.draw_id(device_name)
-                        elif sum(levels) > 0:
-                            base_time = time.time()
-                            subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                levels_sum = sum(levels)
+                now = time.monotonic()
+                if not shared_state.id_key_press_active:
+                    if levels_sum > silence_level_sum_threshold:
+                        if idle_mode == 'silent-pulse':
+                            if levels_sum >= activity_resume_threshold:
+                                if active_candidate_started_ts is None:
+                                    active_candidate_started_ts = now
+                                if now - active_candidate_started_ts >= activity_resume_hold_sec:
+                                    last_nonzero_frame_ts = now
+                                    idle_mode = None
+                                    idle_mode_started_ts = None
+                                    active_candidate_started_ts = None
+                                    with device_write_lock:
+                                        subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                                else:
+                                    render_silent_pulse(now)
+                            else:
+                                active_candidate_started_ts = None
+                                render_silent_pulse(now)
+                        else:
+                            active_candidate_started_ts = None
+                            last_nonzero_frame_ts = now
+                            idle_mode = None
+                            idle_mode_started_ts = None
+                            with device_write_lock:
+                                subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    else:
+                        active_candidate_started_ts = None
+                        silence_sec = now - last_nonzero_frame_ts
+                        if silence_sec >= silent_pulse_after_sec:
+                            render_silent_pulse(now)
 
                 time.sleep(UPDATE_RATE)
-        self.force_monitor_source()
-        stream = sd.InputStream(
-            samplerate=SAMPLE_RATE,
-            channels=2,
-            blocksize=CHUNK_SIZE,
-            callback=audio_callback,
-            device='default'
-        )
 
         update_thread = threading.Thread(target=update_leds, daemon=True)
         update_thread.start()
 
         with stream:
-            log.debug(f"Running equalizer for {channel} channel on {device_name} with {'EasyEffects' if external_filter else 'Python'} filter")
+            log.debug(
+                f"Running equalizer for {channel} channel on {device_name} "
+                f"using {input_mode} input via '{stream_device}' "
+                f"with {'EasyEffects' if external_filter else 'Python'} filter"
+            )
             try:
                 while not self.done:
                     time.sleep(0.1)
             except KeyboardInterrupt:
                 self.cleanup()
-            finally:
-                self.stream = None
         return True
             
 if __name__ == '__main__':

--- a/led_mon/equalizer_files/visualize.py
+++ b/led_mon/equalizer_files/visualize.py
@@ -82,6 +82,7 @@ def scale_rms(rms, min_db=-60, max_db=0):
     db = 20 * np.log10(rms + 1e-10)
     normalized = np.clip((db - min_db) / (max_db - min_db), 0, 1)
     return int(normalized * 34)
+
 def clamp_positive_float(value, default):
     try:
         parsed = float(value)
@@ -95,6 +96,7 @@ def clamp_nonnegative_int(value, default):
         return parsed if parsed >= 0 else int(default)
     except (TypeError, ValueError):
         return int(default)
+
 def resolve_input_stream_device(input_mode, input_device_hint=None):
     if input_device_hint:
         return input_device_hint
@@ -286,10 +288,6 @@ class Equalizer():
         with self.buffer_lock:
             self.audio_buffer = indata.copy()
         
-    def draw_id(self, device_name):
-        grid = np.zeros((9,34), dtype = int)
-        grid[:,:] = id_patterns['equalizer_paused'] * shared_state.foreground_value
-        self.queue_frame(grid, False)
     def draw_inverted_silence_pulse(self, elapsed_sec, pulse_period_sec, reveal_sec):
         pulse_period_sec = clamp_positive_float(pulse_period_sec, DEFAULT_SILENT_PULSE_PERIOD_SEC)
         reveal_sec = clamp_positive_float(reveal_sec, DEFAULT_SILENT_PULSE_REVEAL_SEC)
@@ -428,6 +426,7 @@ class Equalizer():
                     pulse_period_sec=silent_pulse_period_sec,
                     reveal_sec=silent_pulse_reveal_sec,
                 )
+
             while not self.done:
                 with self.buffer_lock:
                     buffer_snapshot = self.audio_buffer.copy()

--- a/led_mon/led_system_monitor.py
+++ b/led_mon/led_system_monitor.py
@@ -466,15 +466,19 @@ def app(args, base_apps, plugin_apps):
                 suppressed_quadrants_pre_rotation.add('bottom-right')
             elif right_owner_quadrant == 'bottom-right':
                 suppressed_quadrants_pre_rotation.add('top-right')
+            # Keep quadrant schedules aligned even when one quadrant is suppressed by
+            # a sibling panel-scope app; otherwise manual Alt+N can create lasting skew.
             now = time.monotonic()
             for quadrant, apps in quads.items():
                     app = apps[app_idx[quadrant]]
                     suppressed_for_rotation = quadrant in suppressed_quadrants_pre_rotation
-                    can_force_next = next_key_combo_active and not suppressed_for_rotation
+                    can_force_next = next_key_combo_active
                     should_advance = (now - base_time_map[quadrant][app['name']] >= int(app_duration[app['name']])) or can_force_next
                     if should_advance and not freeze_app_switching:
                             if can_force_next:
                                 evdev_next_key_pressed = False
+                            # Suppressed quadrants still rotate state, but should not
+                            # trigger draw-side animation/dispose transitions.
                             if not suppressed_for_rotation:
                                 if 'left' in quadrant:
                                     idx_changed[left_drawing_queue] = True

--- a/led_mon/led_system_monitor.py
+++ b/led_mon/led_system_monitor.py
@@ -89,20 +89,19 @@ def evcode_keyloop():
         try:
             device = evdev.InputDevice(kbd_path)
             for event in device.read_loop():
-                for event in device.read_loop():
-                    if event.type == ecodes.EV_KEY:
-                        if event.value == 1:
-                            keys_pressed.add(event.code)
-                        elif event.value == 0:
-                            keys_pressed.discard(event.code)
+                if event.type == ecodes.EV_KEY:
+                    if event.value == 1:
+                        keys_pressed.add(event.code)
+                    elif event.value == 0:
+                        keys_pressed.discard(event.code)
 
-                        if (ecodes.KEY_LEFTALT in keys_pressed or ecodes.KEY_RIGHTALT in keys_pressed) and ecodes.KEY_F in keys_pressed:
-                            freeze_app_switching = True
-                        elif (ecodes.KEY_LEFTALT in keys_pressed or ecodes.KEY_RIGHTALT in keys_pressed) and ecodes.KEY_U in keys_pressed:
-                            freeze_app_switching = False
-                            
-                        if (ecodes.KEY_LEFTALT in keys_pressed or ecodes.KEY_RIGHTALT in keys_pressed) and ecodes.KEY_N in keys_pressed:
-                            evdev_next_key_pressed = True
+                    if (ecodes.KEY_LEFTALT in keys_pressed or ecodes.KEY_RIGHTALT in keys_pressed) and ecodes.KEY_F in keys_pressed:
+                        freeze_app_switching = True
+                    elif (ecodes.KEY_LEFTALT in keys_pressed or ecodes.KEY_RIGHTALT in keys_pressed) and ecodes.KEY_U in keys_pressed:
+                        freeze_app_switching = False
+
+                    if (ecodes.KEY_LEFTALT in keys_pressed or ecodes.KEY_RIGHTALT in keys_pressed) and ecodes.KEY_N in keys_pressed:
+                        evdev_next_key_pressed = True
         except (PermissionError, FileNotFoundError, OSError) as e:
             log.warning(f"Warning: Cannot access keyboard device {kbd_path}: {e}")
                 

--- a/led_mon/led_system_monitor.py
+++ b/led_mon/led_system_monitor.py
@@ -276,6 +276,63 @@ def app(args, base_apps, plugin_apps):
         "snap": draw_snap,
         "none": lambda *x: x # noop
     }
+
+    panel_scope_conflicts_logged = set()
+    suppressed_panel_apps = {
+        'top-left': None,
+        'bottom-left': None,
+        'top-right': None,
+        'bottom-right': None,
+    }
+
+    def build_app_kwargs(app):
+        if 'args' in app:
+            # Args must be hashable, to support function caching, so convert list values to tuples
+            return {k: tuple(v) if isinstance(v, list) else v for k, v in app['args'].items()}
+        return {}
+
+    def get_panel_scope_owner(panel_name, top_quadrant_name, top_app, bottom_quadrant_name, bottom_app):
+        top_claims_panel = top_app.get("display", True) and top_app.get("scope", None) == "panel"
+        bottom_claims_panel = bottom_app.get("display", True) and bottom_app.get("scope", None) == "panel"
+
+        if top_claims_panel and bottom_claims_panel:
+            conflict_key = (panel_name, top_app.get("name"), bottom_app.get("name"))
+            if conflict_key not in panel_scope_conflicts_logged:
+                panel_scope_conflicts_logged.add(conflict_key)
+                log.warning(
+                    f"Both {top_quadrant_name} ({top_app.get('name')}) and {bottom_quadrant_name} ({bottom_app.get('name')}) "
+                    f"claim scope='panel' on {panel_name} panel; preferring {top_quadrant_name}."
+                )
+            return top_quadrant_name, top_app
+        if top_claims_panel:
+            return top_quadrant_name, top_app
+        if bottom_claims_panel:
+            return bottom_quadrant_name, bottom_app
+        return None, None
+
+    def maybe_dispose_suppressed_panel_app(quadrant_name):
+        if quadrant_name is None:
+            return
+        app = quads[quadrant_name][app_idx[quadrant_name]]
+        dispose_fn = app.get('dispose-fn', None)
+        if dispose_fn is None:
+            return
+
+        signature = (app.get('name'), app_idx[quadrant_name], dispose_fn)
+        if suppressed_panel_apps.get(quadrant_name) == signature:
+            return
+
+        func = app_functions.get(dispose_fn)
+        if func is None:
+            log.error(f"Unrecognized dispose function '{dispose_fn}' for suppressed app '{app.get('name')}' in {quadrant_name}")
+            suppressed_panel_apps[quadrant_name] = signature
+            return
+
+        try:
+            func(**build_app_kwargs(app))
+            suppressed_panel_apps[quadrant_name] = signature
+        except Exception as e:
+            log.error(f"Error disposing suppressed app {app.get('name')} in {quadrant_name}: {e}")
     
     def on_press(key):
         global alt_pressed, i_pressed, n_pressed, freeze_app_switching
@@ -376,44 +433,101 @@ def app(args, base_apps, plugin_apps):
             # Track when an app is changed in either panel, used to manage animation state
             idx_changed = {
                 left_drawing_queue: False,
-                right_drawing_queue: False
             }
+            if len(drawing_queues) > 1:
+                idx_changed[right_drawing_queue] = False
             # A set of apps to be (potentially) disposed
             apps_to_dispose = []
+
+            active_apps = {
+                'top-left': top_left[app_idx['top-left']],
+                'bottom-left': bottom_left[app_idx['bottom-left']],
+                'top-right': top_right[app_idx['top-right']],
+                'bottom-right': bottom_right[app_idx['bottom-right']],
+            }
+
+            left_owner_quadrant, _ = get_panel_scope_owner(
+                "left",
+                'top-left', active_apps['top-left'],
+                'bottom-left', active_apps['bottom-left']
+            )
+            right_owner_quadrant, _ = get_panel_scope_owner(
+                "right",
+                'top-right', active_apps['top-right'],
+                'bottom-right', active_apps['bottom-right']
+            )
+
+            suppressed_quadrants_pre_rotation = set()
+            if left_owner_quadrant == 'top-left':
+                suppressed_quadrants_pre_rotation.add('bottom-left')
+            elif left_owner_quadrant == 'bottom-left':
+                suppressed_quadrants_pre_rotation.add('top-left')
+            if right_owner_quadrant == 'top-right':
+                suppressed_quadrants_pre_rotation.add('bottom-right')
+            elif right_owner_quadrant == 'bottom-right':
+                suppressed_quadrants_pre_rotation.add('top-right')
             for quadrant, apps in quads.items():
+                    if quadrant in suppressed_quadrants_pre_rotation:
+                            continue
                     app = apps[app_idx[quadrant]]
                     if ((time.monotonic() - base_time_map[quadrant][app['name']] >= int(app_duration[app['name']]) \
                         or (next_key_combo_active))) and not freeze_app_switching:
                             evdev_next_key_pressed = False
                             if 'left' in quadrant:
                                 idx_changed[left_drawing_queue] = True
-                            else:
+                            elif len(drawing_queues) > 1:
                                 idx_changed[right_drawing_queue] = True
                             if 'dispose-fn' in app:
                                     apps_to_dispose.append(app)
                             app_idx[quadrant] = (app_idx[quadrant] + 1) % len(quads[quadrant])
                             app = apps[app_idx[quadrant]]
                             base_time_map[quadrant][app['name']] = time.monotonic()
-            left_args = [
-                top_left[app_idx['top-left']],
-                bottom_left[app_idx['bottom-left']],
-            ]
+            left_top_app = top_left[app_idx['top-left']]
+            left_bottom_app = bottom_left[app_idx['bottom-left']]
+            right_top_app = top_right[app_idx['top-right']]
+            right_bottom_app = bottom_right[app_idx['bottom-right']]
 
-            right_args = [
-                top_right[app_idx['top-right']],
-                bottom_right[app_idx['bottom-right']]
-            ]
+            left_owner_quadrant, left_owner_app = get_panel_scope_owner(
+                "left",
+                'top-left', left_top_app,
+                'bottom-left', left_bottom_app
+            )
+            right_owner_quadrant, right_owner_app = get_panel_scope_owner(
+                "right",
+                'top-right', right_top_app,
+                'bottom-right', right_bottom_app
+            )
+
+            left_args = [left_owner_app] if left_owner_app else [left_top_app, left_bottom_app]
+            right_args = [right_owner_app] if right_owner_app else [right_top_app, right_bottom_app]
+
+            left_suppressed_quadrant = None
+            if left_owner_quadrant == 'top-left':
+                left_suppressed_quadrant = 'bottom-left'
+            elif left_owner_quadrant == 'bottom-left':
+                left_suppressed_quadrant = 'top-left'
+
+            right_suppressed_quadrant = None
+            if right_owner_quadrant == 'top-right':
+                right_suppressed_quadrant = 'bottom-right'
+            elif right_owner_quadrant == 'bottom-right':
+                right_suppressed_quadrant = 'top-right'
+
+            currently_suppressed_quadrants = set(filter(None, [left_suppressed_quadrant, right_suppressed_quadrant]))
+            for quadrant in suppressed_panel_apps:
+                if quadrant not in currently_suppressed_quadrants:
+                    suppressed_panel_apps[quadrant] = None
 
             # Capture animating state so we can restart it if necessary after stopping it for ID display
-            animating_left = left_args[0].get("animate", False) or left_args[1].get("animate", False)
-            animating_right = right_args[0].get("animate", False) or right_args[1].get("animate", False)
+            animating_left = any(arg.get("animate", False) for arg in left_args)
+            animating_right = any(arg.get("animate", False) for arg in right_args)
             
             if id_key_combo_active:
                 # Show app IDs for each quadrant or panel
                 draw_outline_border(grid, background_value)
-                #If app takes up entire panel, we draw the ID differently
-                if left_args[0].get("scope", None) == "panel":
-                    draw_id(grid, left_args[0]['name'], foreground_value, args=left_args[0].get('args', None))
+                # If app takes up entire panel, draw the panel app ID only
+                if left_owner_app:
+                    draw_id(grid, left_owner_app['name'], foreground_value, args=left_owner_app.get('args', None))
                 else:
                     draw_ids(grid, left_args[0]['name'], left_args[1]['name'], foreground_value,
                         targs=left_args[0].get('args', None), bargs=left_args[1].get('args', None))
@@ -422,11 +536,11 @@ def app(args, base_apps, plugin_apps):
                 if len(drawing_queues) > 1:  # Right panel exists
                     grid = np.zeros((9,34), dtype = int)
                     draw_outline_border(grid, background_value)
-                    if right_args[0].get("scope", None) == "panel":
-                        draw_id(grid, right_args[0]['name'], foreground_value, args=right_args[0].get('args', None))
+                    if right_owner_app:
+                        draw_id(grid, right_owner_app['name'], foreground_value, args=right_owner_app.get('args', None))
                     else:
                         draw_ids(grid, right_args[0]['name'], right_args[1]['name'], foreground_value,
-                            targs=right_args[0].get('args', None), bargs=right_args[0].get('args', None))
+                            targs=right_args[0].get('args', None), bargs=right_args[1].get('args', None))
                     right_drawing_queue.put((grid, False))
                 time.sleep(0.1)
                 latch_key_combo = True
@@ -437,9 +551,13 @@ def app(args, base_apps, plugin_apps):
                 if i == 0:
                     panel = 'left'
                     _args = left_args
+                    suppressed_quadrant = left_suppressed_quadrant
                 else:
                     panel = 'right'
                     _args = right_args
+                    suppressed_quadrant = right_suppressed_quadrant
+
+                maybe_dispose_suppressed_panel_app(suppressed_quadrant)
                 # For persistent-draw apps, we don't submit the grid to the drawing queue
                 persistent_draw = False
                 for j, arg in enumerate(_args):
@@ -456,10 +574,7 @@ def app(args, base_apps, plugin_apps):
                     try:
                         func = app_functions[arg_name]
                         func_args = [arg_name, grid, foreground_value, idx]
-                        kwargs = {}
-                        if 'args' in arg:
-                            #Args must be hashable, to support function caching, so convert any list values in dicts to tuples
-                            kwargs = {k: tuple(v) if isinstance(v, list) else v for k, v in arg['args'].items()}
+                        kwargs = build_app_kwargs(arg)
                         func(*func_args, **kwargs)
                         animate = arg.get("animate", False)
                     except KeyError:
@@ -468,7 +583,7 @@ def app(args, base_apps, plugin_apps):
                         log.error(f"Error {e} with app {arg_name} for {loc} {panel}")
                     # Single border draw for mem and bat together
                     if arg_name == 'mem-bat': arg_name = 'mem'
-                    if kwargs.get('border', True):
+                    if kwargs.get('border', True) and arg.get("scope", None) != "panel":
                         draw_app_border(arg_name, grid, background_value, idx)
                 do_animate = None
                 if idx_changed[draw_queue]:
@@ -486,9 +601,7 @@ def app(args, base_apps, plugin_apps):
                 dispose_fn = app.get('dispose-fn', None)
                 if dispose_fn:
                     func = app_functions[dispose_fn]
-                    kwargs = {}
-                    if 'args' in app:
-                        kwargs = {k: tuple(v) if isinstance(v, list) else v for k, v in app['args'].items()}
+                    kwargs = build_app_kwargs(app)
                     func(**kwargs)
             del apps_to_dispose
             time.sleep(0.1)     

--- a/led_mon/led_system_monitor.py
+++ b/led_mon/led_system_monitor.py
@@ -466,22 +466,25 @@ def app(args, base_apps, plugin_apps):
                 suppressed_quadrants_pre_rotation.add('bottom-right')
             elif right_owner_quadrant == 'bottom-right':
                 suppressed_quadrants_pre_rotation.add('top-right')
+            now = time.monotonic()
             for quadrant, apps in quads.items():
-                    if quadrant in suppressed_quadrants_pre_rotation:
-                            continue
                     app = apps[app_idx[quadrant]]
-                    if ((time.monotonic() - base_time_map[quadrant][app['name']] >= int(app_duration[app['name']]) \
-                        or (next_key_combo_active))) and not freeze_app_switching:
-                            evdev_next_key_pressed = False
-                            if 'left' in quadrant:
-                                idx_changed[left_drawing_queue] = True
-                            elif len(drawing_queues) > 1:
-                                idx_changed[right_drawing_queue] = True
-                            if 'dispose-fn' in app:
-                                    apps_to_dispose.append(app)
+                    suppressed_for_rotation = quadrant in suppressed_quadrants_pre_rotation
+                    can_force_next = next_key_combo_active and not suppressed_for_rotation
+                    should_advance = (now - base_time_map[quadrant][app['name']] >= int(app_duration[app['name']])) or can_force_next
+                    if should_advance and not freeze_app_switching:
+                            if can_force_next:
+                                evdev_next_key_pressed = False
+                            if not suppressed_for_rotation:
+                                if 'left' in quadrant:
+                                    idx_changed[left_drawing_queue] = True
+                                elif len(drawing_queues) > 1:
+                                    idx_changed[right_drawing_queue] = True
+                                if 'dispose-fn' in app:
+                                        apps_to_dispose.append(app)
                             app_idx[quadrant] = (app_idx[quadrant] + 1) % len(quads[quadrant])
                             app = apps[app_idx[quadrant]]
-                            base_time_map[quadrant][app['name']] = time.monotonic()
+                            base_time_map[quadrant][app['name']] = now
             left_top_app = top_left[app_idx['top-left']]
             left_bottom_app = bottom_left[app_idx['bottom-left']]
             right_top_app = top_right[app_idx['top-right']]

--- a/led_mon/plugins/equalizer_plugin.py
+++ b/led_mon/plugins/equalizer_plugin.py
@@ -28,9 +28,45 @@ equalizers = {}
 equalizer_retry_after = {}
 EQUALIZER_RETRY_BACKOFF_SEC = 30
 
+def parse_float_arg(kwargs, key, default):
+    value = kwargs.get(key, default)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        log.warning(f"Invalid equalizer arg '{key}={value}', using default {default}.")
+        return float(default)
+def parse_int_arg(kwargs, key, default):
+    value = kwargs.get(key, default)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        log.warning(f"Invalid equalizer arg '{key}={value}', using default {default}.")
+        return int(default)
+
+def normalize_input_mode(value):
+    mode = str(value or "playback").strip().lower()
+    if mode in ("playback", "monitor", "output"):
+        return "playback"
+    if mode in ("microphone", "mic", "input", "capture"):
+        return "microphone"
+    log.warning(f"Invalid equalizer input mode '{value}', defaulting to 'playback'.")
+    return "playback"
+
 def run_equalizer(_, grid, foreground_value, idx, **kwargs):
     external_filter = kwargs.get('external-filter', False)
     side = kwargs.get('side', None)
+    input_mode = normalize_input_mode(kwargs.get('input-mode', 'playback'))
+    input_device = kwargs.get('input-device', None)
+    default_level_gain = 0.75 if input_mode == 'microphone' else 1.35
+    default_noise_gate_level = 18 if input_mode == 'microphone' else 1
+    default_silence_sum_threshold = 48 if input_mode == 'microphone' else 2
+    level_gain = parse_float_arg(kwargs, 'level-gain', default_level_gain)
+    noise_gate_level = parse_int_arg(kwargs, 'noise-gate-level', default_noise_gate_level)
+    silence_level_sum_threshold = parse_int_arg(kwargs, 'silence-level-sum-threshold', default_silence_sum_threshold)
+    zero_frame_delay_sec = parse_float_arg(kwargs, 'zero-frame-delay-sec', 4.0)
+    silent_pulse_after_sec = parse_float_arg(kwargs, 'silent-pulse-after-sec', 12.0)
+    silent_pulse_period_sec = parse_float_arg(kwargs, 'silent-pulse-period-sec', 3.8)
+    silent_pulse_reveal_sec = parse_float_arg(kwargs, 'silent-pulse-reveal-sec', 5.0)
     if side not in ('left', 'right'):
         log.error(f"Unexpected equalizer side arg '{side}'. Expected 'left' or 'right'.")
         return
@@ -57,7 +93,20 @@ def run_equalizer(_, grid, foreground_value, idx, **kwargs):
 
     def _run():
         try:
-            ok = eq.run(channel=channel, external_filter=external_filter, device_name=device[1])
+            ok = eq.run(
+                channel=channel,
+                external_filter=external_filter,
+                device_name=device[1],
+                input_mode=input_mode,
+                input_device=input_device,
+                level_gain=level_gain,
+                noise_gate_level=noise_gate_level,
+                silence_level_sum_threshold=silence_level_sum_threshold,
+                zero_frame_notify_delay_sec=zero_frame_delay_sec,
+                silent_pulse_after_sec=silent_pulse_after_sec,
+                silent_pulse_period_sec=silent_pulse_period_sec,
+                silent_pulse_reveal_sec=silent_pulse_reveal_sec,
+            )
             if ok is False:
                 equalizer_retry_after[side] = time.time() + EQUALIZER_RETRY_BACKOFF_SEC
         except Exception as e:

--- a/led_mon/plugins/equalizer_plugin.py
+++ b/led_mon/plugins/equalizer_plugin.py
@@ -1,14 +1,14 @@
 # Built In Dependencies
-from statistics import mean
 import os
 import numpy as np
 import threading
 import logging
+import time
 
 # Internal dependencies
 from led_mon.patterns import letters_5_x_6, numerals
 from led_mon import drawing
-from led_mon.equalizer_files.visualize import Equalizer
+from led_mon.equalizer_files.visualize import Equalizer, has_inputmodule_control
 from led_mon.shared_state import discover_led_devices
 
 log = logging.getLogger(__name__)
@@ -25,35 +25,63 @@ log.setLevel(log_level)
 ####  Monitor functions ####
 
 equalizers = {}
+equalizer_retry_after = {}
+EQUALIZER_RETRY_BACKOFF_SEC = 30
 
 def run_equalizer(_, grid, foreground_value, idx, **kwargs):
-    external_filter = kwargs['external-filter']
-    side = kwargs['side']
-    # device => ('<port>', '<name>')
-    devices: tuple[str, str] = discover_led_devices()
-    if side == 'left':
-        channel = 0
-        device = devices[0]
-    elif side == 'right':
-        channel = 1
-        device = devices[1]
-    else:
-        log.error(f"Unexpected device arg {kwargs['device']}")
-    if not side in equalizers:
-        equalizers[side] = Equalizer(device_location = device[0])
-        eq_thread = threading.Thread(target=lambda: equalizers[side].run(channel=channel, external_filter=external_filter, device_name=device[1]), daemon=True)
-        eq_thread.start()
+    external_filter = kwargs.get('external-filter', False)
+    side = kwargs.get('side', None)
+    if side not in ('left', 'right'):
+        log.error(f"Unexpected equalizer side arg '{side}'. Expected 'left' or 'right'.")
+        return
+
+    if not has_inputmodule_control():
+        log.error("inputmodule-control is not available on PATH. Skipping equalizer startup.")
+        return
+
+    if side in equalizers:
+        return
+    if time.time() < equalizer_retry_after.get(side, 0):
+        return
+
+    # device tuple => ('<location>', '<serial device>')
+    devices: tuple[str, str] = discover_led_devices() or []
+    channel = 0 if side == 'left' else 1
+    if len(devices) <= channel:
+        log.warning(f"Equalizer requested for {side} side, but matching LED device was not discovered.")
+        return
+    device = devices[channel]
+
+    eq = Equalizer(device_location=device[0])
+    equalizers[side] = eq
+
+    def _run():
+        try:
+            ok = eq.run(channel=channel, external_filter=external_filter, device_name=device[1])
+            if ok is False:
+                equalizer_retry_after[side] = time.time() + EQUALIZER_RETRY_BACKOFF_SEC
+        except Exception as e:
+            log.error(f"Equalizer runtime error on {side} side: {e}")
+            equalizer_retry_after[side] = time.time() + EQUALIZER_RETRY_BACKOFF_SEC
+        finally:
+            if equalizers.get(side) is eq:
+                del equalizers[side]
+
+    eq_thread = threading.Thread(target=_run, daemon=True)
+    eq_thread.start()
     if len(equalizers) > 2:
         log.info(f"run_equalizer: Active equalizers: {len(equalizers)}")
     
 def dispose_equalizer(**kwargs):
-    side = kwargs['side']
-    if side in equalizers:
-        equalizers[side].stop()
-        # Optional (if resource leak found): Join to ensure clean exit
-        # But since daemon, not strictly needed; helps for debugging
-        # equalizers[side].drawing_thread.join(timeout=2)
-        del equalizers[side]
+    side = kwargs.get('side', None)
+    if side is None:
+        log.error("dispose_equalizer called without required 'side' arg.")
+        return
+
+    eq = equalizers.pop(side, None)
+    if eq is not None:
+        eq.stop()
+    equalizer_retry_after.pop(side, None)
     if len(equalizers) > 2:
         log.info(f"dispose_equalizer: Active equalizers: {len(equalizers)}")
 

--- a/led_mon/plugins/time_weather_plugin.py
+++ b/led_mon/plugins/time_weather_plugin.py
@@ -18,7 +18,12 @@ from led_mon import drawing
 Weather = namedtuple('Weather', ['Weather', 'temp', 'wind_chill', 'wind_speed', 'wind_speed_symbol', 'wind_dir', 'temp_symbol', 'condition'])
 
 OPENWEATHER_HOST = 'https://api.openweathermap.org'
+OPEN_METEO_HOST = 'https://api.open-meteo.com'
+OPEN_METEO_GEOCODE_HOST = 'https://geocoding-api.open-meteo.com'
 IPIFY_HOST = 'https://api.ipify.org'
+IPWHO_HOST = 'https://ipwho.is'
+IPAPI_HOST = 'https://ipapi.co/json'
+IPINFO_HOST = 'https://ipinfo.io/json'
 
 log = logging.getLogger(__name__)
 LOG_LEVELS = {
@@ -46,25 +51,341 @@ class Measures(Enum):
 # No need to invalidate cache since location per given zip is fixed
 def get_location_by_zip(zip_info, weather_api_key):
     zip_code, country = zip_info
-    result = requests.get(f"{OPENWEATHER_HOST}/geo/1.0/zip?zip={zip_code},{country}&appid={weather_api_key}").json()
+    result = requests.get(
+        f"{OPENWEATHER_HOST}/geo/1.0/zip?zip={zip_code},{country}&appid={weather_api_key}",
+        timeout=10
+    ).json()
+    if not isinstance(result, dict) or "lat" not in result or "lon" not in result:
+        details = result.get("message", result) if isinstance(result, dict) else result
+        raise Exception(f"OpenWeather zip lookup failed: {details}")
     lat = result['lat']
     lon = result['lon']
     loc = lat, lon
     return loc
 
 @cache
+def get_location_by_zip_open_meteo(zip_info):
+    zip_code, country = zip_info
+    country_code = country.upper() if country else None
+    params = {
+        "name": str(zip_code),
+        "count": 1,
+        "language": "en",
+        "format": "json",
+    }
+    if country_code:
+        params["countryCode"] = country_code
+
+    result = requests.get(
+        f"{OPEN_METEO_GEOCODE_HOST}/v1/search",
+        params=params,
+        timeout=10
+    ).json()
+    results = result.get("results") if isinstance(result, dict) else None
+
+    if not results and country_code:
+        fallback_result = requests.get(
+            f"{OPEN_METEO_GEOCODE_HOST}/v1/search",
+            params={
+                "name": f"{zip_code} {country_code}",
+                "count": 1,
+                "language": "en",
+                "format": "json",
+            },
+            timeout=10
+        ).json()
+        if isinstance(fallback_result, dict):
+            result = fallback_result
+            results = fallback_result.get("results")
+
+    if not isinstance(results, list) or len(results) == 0:
+        details = result.get("reason", result) if isinstance(result, dict) else result
+        raise Exception(f"Open-Meteo geocoding lookup failed: {details}")
+
+    lat = results[0].get("latitude")
+    lon = results[0].get("longitude")
+    if lat is None or lon is None:
+        raise Exception("Open-Meteo geocoding response did not include coordinates.")
+    return lat, lon
+
+@cache
 # Cache results so we avoid exceeding the API rate limit
 # No need to invalidate cache since location per given IP address is generally fixed
 def get_location_by_ip(ip_api_key, ip):
-    from iplocate import IPLocateClient
+    try:
+        from iplocate import IPLocateClient
+    except ImportError as e:
+        raise Exception("IP-based weather lookup requires the optional `iplocate` dependency.") from e
     client = IPLocateClient(api_key=ip_api_key)
     result = client.lookup(ip)
+    if result.latitude is None or result.longitude is None:
+        raise Exception("IP-based location lookup returned no coordinates.")
     loc = result.latitude, result.longitude
     try:
         log.debug(f"Getting weather for {result.city}, {result.subdivision}, {result.country_code}, geo coordinates: {loc}")
     except:
         pass
     return loc
+
+@cache
+def get_location_by_ip_keyless():
+    errors = []
+    try:
+        result = requests.get(IPWHO_HOST, timeout=10).json()
+        if isinstance(result, dict) and result.get("success") is True:
+            lat = result.get("latitude")
+            lon = result.get("longitude")
+            if lat is not None and lon is not None:
+                return lat, lon
+        errors.append(f"ipwho.is: {result}")
+    except Exception as e:
+        errors.append(f"ipwho.is: {e}")
+
+    try:
+        result = requests.get(IPAPI_HOST, timeout=10).json()
+        if isinstance(result, dict):
+            lat = result.get("latitude")
+            lon = result.get("longitude")
+            if lat is not None and lon is not None:
+                return lat, lon
+        errors.append(f"ipapi.co: {result}")
+    except Exception as e:
+        errors.append(f"ipapi.co: {e}")
+
+    try:
+        result = requests.get(IPINFO_HOST, timeout=10).json()
+        if isinstance(result, dict):
+            loc = result.get("loc")
+            if isinstance(loc, str) and "," in loc:
+                lat, lon = loc.split(",", 1)
+                return float(lat), float(lon)
+        errors.append(f"ipinfo.io: {result}")
+    except Exception as e:
+        errors.append(f"ipinfo.io: {e}")
+
+    raise Exception(f"No location method configured and keyless IP geolocation failed ({'; '.join(errors)})")
+
+
+def get_temp_symbol(units):
+    return 'degC' if units == 'metric' else 'degF' if units == 'imperial' else 'degK'
+
+
+def get_open_meteo_condition(weather_code):
+    try:
+        code = int(weather_code)
+    except (TypeError, ValueError):
+        return 'clouds'
+
+    if code == 0:
+        return 'clear'
+    if code in [1, 2, 3]:
+        return 'clouds'
+    if code in [45, 48]:
+        return 'mist-like'
+    if code in [51, 53, 55, 56, 57]:
+        return 'drizzle'
+    if code in [61, 63, 65, 66, 67, 80, 81, 82]:
+        return 'rain'
+    if code in [71, 73, 75, 77, 85, 86]:
+        return 'snow'
+    if code in [95, 96, 99]:
+        return 'thunderstorm'
+    return 'clouds'
+
+
+def apply_standard_temperature_conversion(value, units):
+    if units == 'standard' and value is not None:
+        return value + 273.15
+    return value
+
+
+def get_location(zip_info, lat_lon, ip_api_key, weather_api_key):
+    if lat_lon:
+        if len(lat_lon) != 2:
+            raise Exception("Invalid lat_lon value. Expected [lat, lon].")
+        return float(lat_lon[0]), float(lat_lon[1])
+
+    if zip_info:
+        if weather_api_key:
+            try:
+                return get_location_by_zip(zip_info, weather_api_key)
+            except Exception as e:
+                log.warning(f"OpenWeather zip geocoding failed; falling back to Open-Meteo geocoding: {e}")
+        return get_location_by_zip_open_meteo(zip_info)
+
+    if ip_api_key:
+        ip = requests.get(IPIFY_HOST, timeout=10).text
+        return get_location_by_ip(ip_api_key, ip)
+
+    return get_location_by_ip_keyless()
+
+
+def get_weather_fields(source, units, temp_symbol, mist_like):
+    if not isinstance(source, dict):
+        raise Exception(f"OpenWeather response item has unexpected type: {type(source)}")
+
+    main = source.get("main")
+    wind = source.get("wind")
+    weather_data = source.get("weather")
+
+    if not isinstance(main, dict) or not isinstance(wind, dict) or not isinstance(weather_data, list) or len(weather_data) == 0:
+        raise Exception("OpenWeather response is missing one or more required fields: main, wind, weather")
+
+    weather_head = weather_data[0]
+    if not isinstance(weather_head, dict):
+        raise Exception("OpenWeather response weather entry is malformed")
+
+    temp = main.get("temp")
+    feels_like = main.get("feels_like")
+    wind_speed = wind.get("speed")
+    wind_dir = wind.get("deg")
+    condition = weather_head.get("main")
+
+    missing_fields = []
+    if temp is None: missing_fields.append("main.temp")
+    if feels_like is None: missing_fields.append("main.feels_like")
+    if wind_speed is None: missing_fields.append("wind.speed")
+    if wind_dir is None: missing_fields.append("wind.deg")
+    if condition is None: missing_fields.append("weather[0].main")
+    if missing_fields:
+        raise Exception(f"OpenWeather response is missing required values: {', '.join(missing_fields)}")
+
+    wind_speed_symbol = 'mi' if units == 'imperial' else 'km'
+    if condition in mist_like:
+        condition = 'mist-like'
+
+    return temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition
+
+
+def get_weather_by_openweather(loc, weather_api_key, units, forecast, forecast_day, forecast_hour, mist_like):
+    temp_symbol = get_temp_symbol(units)
+    if forecast:
+        forecast_data = requests.get(
+            f"{OPENWEATHER_HOST}/data/2.5/forecast?lat={loc[0]}&lon={loc[1]}&appid={weather_api_key}&units={units}",
+            timeout=10
+        ).json()
+        if not isinstance(forecast_data, dict) or "list" not in forecast_data or not isinstance(forecast_data["list"], list) or len(forecast_data["list"]) == 0:
+            details = forecast_data.get("message", forecast_data) if isinstance(forecast_data, dict) else forecast_data
+            raise Exception(f"OpenWeather forecast lookup failed: {details}")
+
+        target_date = (datetime.now(ZoneInfo('GMT')).date() + timedelta(days=forecast_day))
+        for fc in forecast_data['list']:
+            dt = datetime.strptime(fc['dt_txt'], '%Y-%m-%d %H:%M:%S')
+            if dt.date() == target_date and dt.hour >= forecast_hour:
+                temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition = get_weather_fields(fc, units, temp_symbol, mist_like)
+                # Convert m/sec to km/hr (* 3,600 / 1,000)
+                if units != 'imperial':
+                    wind_speed *= 3.6
+                forecast_weather = Weather('Forecast', temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition)
+                log.debug(f"OpenWeather forecast selected ({fc['dt_txt']}): {forecast_weather}")
+                return forecast_weather
+
+        fc = forecast_data['list'][-1]
+        temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition = get_weather_fields(fc, units, temp_symbol, mist_like)
+        # Convert m/sec to km/hr (* 3,600 / 1,000)
+        if units != 'imperial':
+            wind_speed *= 3.6
+        forecast_weather = Weather('Forecast', temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition)
+        log.debug(f"OpenWeather forecast fallback (latest): {forecast_weather}")
+        return forecast_weather
+
+    current = requests.get(
+        f"{OPENWEATHER_HOST}/data/2.5/weather?lat={loc[0]}&lon={loc[1]}&appid={weather_api_key}&units={units}",
+        timeout=10
+    ).json()
+    if not isinstance(current, dict) or "main" not in current:
+        details = current.get("message", current) if isinstance(current, dict) else current
+        raise Exception(f"OpenWeather current-weather lookup failed: {details}")
+
+    temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition = get_weather_fields(current, units, temp_symbol, mist_like)
+    # Convert m/sec to km/hr (* 3,600 / 1,000)
+    if units != 'imperial':
+        wind_speed *= 3.6
+    weather = Weather('Current', temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition)
+    log.debug(f"OpenWeather current weather: {weather}")
+    return weather
+
+
+def get_weather_by_open_meteo(loc, units, forecast, forecast_day, forecast_hour):
+    temp_symbol = get_temp_symbol(units)
+    temperature_unit = 'fahrenheit' if units == 'imperial' else 'celsius'
+    wind_speed_unit = 'mph' if units == 'imperial' else 'kmh'
+    wind_speed_symbol = 'mi' if units == 'imperial' else 'km'
+
+    params = {
+        "latitude": loc[0],
+        "longitude": loc[1],
+        "temperature_unit": temperature_unit,
+        "wind_speed_unit": wind_speed_unit,
+        "timezone": "GMT",
+    }
+    if forecast:
+        params["hourly"] = "temperature_2m,apparent_temperature,wind_speed_10m,wind_direction_10m,weather_code"
+    else:
+        params["current"] = "temperature_2m,apparent_temperature,wind_speed_10m,wind_direction_10m,weather_code"
+
+    result = requests.get(
+        f"{OPEN_METEO_HOST}/v1/forecast",
+        params=params,
+        timeout=10
+    ).json()
+    if not isinstance(result, dict):
+        raise Exception("Open-Meteo returned an unexpected response payload.")
+    if result.get("error", False):
+        raise Exception(f"Open-Meteo lookup failed: {result.get('reason', result)}")
+
+    if forecast:
+        hourly = result.get("hourly", {})
+        times = hourly.get("time", [])
+        if not isinstance(times, list) or len(times) == 0:
+            raise Exception("Open-Meteo forecast response did not include hourly time data.")
+
+        target_date = (datetime.now(ZoneInfo('GMT')).date() + timedelta(days=forecast_day))
+        selected_idx = None
+        for idx, dt_raw in enumerate(times):
+            dt = datetime.fromisoformat(dt_raw)
+            if dt.date() == target_date and dt.hour >= forecast_hour:
+                selected_idx = idx
+                break
+        if selected_idx is None:
+            selected_idx = len(times) - 1
+
+        def hourly_at(key):
+            values = hourly.get(key, [])
+            if not isinstance(values, list) or selected_idx >= len(values):
+                raise Exception(f"Open-Meteo forecast response missing hourly field: {key}")
+            return values[selected_idx]
+
+        temp = hourly_at("temperature_2m")
+        feels_like = hourly_at("apparent_temperature")
+        wind_speed = hourly_at("wind_speed_10m")
+        wind_dir = hourly_at("wind_direction_10m")
+        condition = get_open_meteo_condition(hourly_at("weather_code"))
+
+        temp = apply_standard_temperature_conversion(temp, units)
+        feels_like = apply_standard_temperature_conversion(feels_like, units)
+        forecast_weather = Weather('Forecast', temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition)
+        log.debug(f"Open-Meteo forecast weather: {forecast_weather}")
+        return forecast_weather
+
+    current = result.get("current", {})
+    if not isinstance(current, dict):
+        raise Exception("Open-Meteo current-weather response is malformed.")
+
+    temp = current.get("temperature_2m")
+    feels_like = current.get("apparent_temperature")
+    wind_speed = current.get("wind_speed_10m")
+    wind_dir = current.get("wind_direction_10m")
+    weather_code = current.get("weather_code")
+    if any(value is None for value in [temp, feels_like, wind_speed, wind_dir, weather_code]):
+        raise Exception("Open-Meteo current-weather response is missing one or more required fields.")
+
+    temp = apply_standard_temperature_conversion(temp, units)
+    feels_like = apply_standard_temperature_conversion(feels_like, units)
+    condition = get_open_meteo_condition(weather_code)
+    weather = Weather('Current', temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition)
+    log.debug(f"Open-Meteo current weather: {weather}")
+    return weather
 
 ####  Monitor functions ####
 
@@ -91,7 +412,6 @@ class WeatherMonitor:
     @cache
     # Cache results so we avoid exceeding the API rate limit
     def get(fs_dict):
-        ip = requests.get(IPIFY_HOST).text
         ip_api_key = os.environ.get("IP_LOCATE_API_KEY", None)
         weather_api_key = os.environ.get("OPENWEATHER_API_KEY", None)
 
@@ -102,55 +422,36 @@ class WeatherMonitor:
         lat_lon = args_dict.get('lat_lon', None)
         units = args_dict.get('units', 'metric')
         forecast = args_dict.get('forecast', False)
-        forecast_day = args_dict.get('forecast_day', 1)
-        forecast_hour = args_dict.get('forecast_hour', 12)
+        forecast_day = int(args_dict.get('forecast_day', 1))
+        forecast_hour = int(args_dict.get('forecast_hour', 12))
         mist_like = ['Mist', 'Fog', 'Dust', 'Haze', 'Smoke', 'Squall', 'Ash', 'Sand', 'Tornado']
 
         try:
-            if lat_lon:
-                loc = lat_lon
-            elif zip_info:
-                loc = get_location_by_zip(zip_info, weather_api_key)
-            elif ip_api_key:
-                loc = get_location_by_ip(ip_api_key, ip)
-            else:
-                raise Exception("No location method configured")
-            
-            temp_symbol = 'degC'if units == 'metric' else 'degF' if units == 'imperial' else 'degK'
+            if units not in ['metric', 'imperial', 'standard']:
+                log.warning(f"Unrecognized weather units '{units}', defaulting to metric")
+                units = 'metric'
 
-            if forecast:
-                forecast = requests.get(f"{OPENWEATHER_HOST}/data/2.5/forecast?lat={loc[0]}&lon={loc[1]}&appid={weather_api_key}&units={units}").json()
-                target_date = (datetime.now(ZoneInfo('GMT')).date() + timedelta(days=forecast_day))
-                for fc in forecast['list']:
-                    dt = datetime.strptime(fc['dt_txt'], '%Y-%m-%d %H:%M:%S')
-                    if dt.date() == target_date and dt.hour >= forecast_hour:
-                        temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition = fc['main']['temp'], fc['main']['feels_like'], fc['wind']['speed'], 'mi' if units == 'imperial' else 'km', fc['wind']['deg'], temp_symbol, fc['weather'][0]['main']
-                        if condition in mist_like: condition= 'mist-like'
-                        # Convert m/sec to km/hr (* 3,600 / 1,000)
-                        if units != 'imperial': wind_speed *= 3.6
-                        forecast_weather = Weather('Forecast', temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition)
-                        log.debug(f"Forecast for time ({fc['dt_txt']}) : {forecast_weather}")
-                        log.debug(f"Forecast: {forecast_weather}")
-                        return forecast_weather
-                forecast = forecast['list'][-1]
-                # print(f"Forecast weather for latest time availabe: {forecast['dt_txt']}")
-                temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition = forecast['main']['temp'], forecast['main']['feels_like'], forecast['wind']['speed'], 'mi' if units == 'imperial' else 'km', forecast['wind']['deg'], temp_symbol, forecast['weather'][0]['main']
-                # Convert m/sec to km/hr (* 3,600 / 1,000)
-                if units != 'imperial': wind_speed *= 3.6
-                if condition in mist_like: condition= 'mist-like'
-                forecast_weather = Weather('Forecast', temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition)
-                log.debug(f"Forecast for latest available time ({forecast['dt_txt']}) : {forecast_weather}")
-                return forecast_weather
-            else:
-                current = requests.get(f"{OPENWEATHER_HOST}/data/2.5/weather?lat={loc[0]}&lon={loc[1]}&appid={weather_api_key}&units={units}").json()
+            loc = get_location(zip_info, lat_lon, ip_api_key, weather_api_key)
+            provider_errors = []
 
-                temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition = current['main']['temp'], current['main']['feels_like'], current['wind']['speed'], 'mi' if units == 'imperial' else 'km', current['wind']['deg'], temp_symbol, current['weather'][0]['main']
-                # Convert m/sec to km/hr (* 3,600 / 1,000)
-                if units != 'imperial': wind_speed *= 3.6
-                if condition in mist_like: condition= 'mist-like'
-                weather = Weather('Current', temp, feels_like, wind_speed, wind_speed_symbol, wind_dir, temp_symbol, condition)
-                log.debug(f"Weather: {weather}")
+            if weather_api_key:
+                try:
+                    weather = get_weather_by_openweather(loc, weather_api_key, units, forecast, forecast_day, forecast_hour, mist_like)
+                    log.debug("Weather provider: OpenWeather")
+                    return weather
+                except Exception as e:
+                    provider_errors.append(f"OpenWeather: {e}")
+                    log.warning(f"OpenWeather weather lookup failed; falling back to Open-Meteo: {e}")
+            else:
+                log.info("OPENWEATHER_API_KEY is not set; using Open-Meteo fallback provider.")
+
+            try:
+                weather = get_weather_by_open_meteo(loc, units, forecast, forecast_day, forecast_hour)
+                log.debug("Weather provider: Open-Meteo")
                 return weather
+            except Exception as e:
+                provider_errors.append(f"Open-Meteo: {e}")
+                raise Exception(" | ".join(provider_errors))
         except Exception as e:
             log.error(f"Error getting weather: {e}")
             return None
@@ -167,6 +468,9 @@ VALID_MEASURES = ['temp_condition', 'wind_chill', 'wind']
 
 def get_next_measure(measures, duration):
     measures = list(filter(lambda m: m in VALID_MEASURES, measures))
+    if len(measures) == 0:
+        log.warning("No valid weather measures configured; defaulting to temp_condition")
+        measures = [Measures.TEMP_COND.value]
     base_time = time.monotonic()
     measure_idx = 0
     while True:
@@ -242,8 +546,8 @@ def repeat_function(interval, func, *args, **kwargs):
     Timer(interval, wrapper).start()
 
 
-# Get fresh weather data every 30 secs. Two calls per minute will be well within the openweather API
-# free tierlimit of 60 calls/minute and 1,000,000 calls/month
+# Get fresh weather data every 30 secs.
+# Requests are cached between refreshes regardless of provider.
 repeat_function(30, weather_monitor.get.cache_clear)
 
 draw_chars = getattr(drawing, 'draw_chars_list')

--- a/ledmatrixmonitoring.nix
+++ b/ledmatrixmonitoring.nix
@@ -1,0 +1,422 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.led-matrix-monitoring;
+  yamlFormat = pkgs.formats.yaml {};
+  legacyMetricType = types.enum [ "cpu" "net" "disk" "mem-bat" "none" "temp" "fan" ];
+
+  appType = types.submodule ({ ... }: {
+    options = {
+      name = mkOption {
+        type = types.str;
+        description = "App name as defined by the LED Matrix monitor (built-in or plugin app).";
+        example = "cpu";
+      };
+
+      duration = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = "Optional per-app duration in seconds. Falls back to layout duration when unset.";
+      };
+
+      animate = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to animate the app output.";
+      };
+
+      scope = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Optional app scope (for example `panel`).";
+      };
+
+      persistentDraw = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether the app is responsible for continuously drawing during its active window.";
+      };
+
+      disposeFn = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Optional dispose function key for persistent-draw apps.";
+      };
+
+      display = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether this app should render pixels during its configured slice.";
+      };
+
+      args = mkOption {
+        type = types.attrsOf types.anything;
+        default = {};
+        description = "Optional app-specific arguments.";
+      };
+    };
+  });
+
+  layoutType = types.submodule {
+    options = {
+      duration = mkOption {
+        type = types.ints.positive;
+        default = 10;
+        description = "Default duration in seconds for app rotation.";
+      };
+
+      quadrants = mkOption {
+        type = types.submodule {
+          options = {
+            topLeft = mkOption {
+              type = types.listOf appType;
+              default = [];
+              description = "Apps displayed in the top-left quadrant, in rotation order.";
+            };
+            bottomLeft = mkOption {
+              type = types.listOf appType;
+              default = [];
+              description = "Apps displayed in the bottom-left quadrant, in rotation order.";
+            };
+            topRight = mkOption {
+              type = types.listOf appType;
+              default = [];
+              description = "Apps displayed in the top-right quadrant, in rotation order.";
+            };
+            bottomRight = mkOption {
+              type = types.listOf appType;
+              default = [];
+              description = "Apps displayed in the bottom-right quadrant, in rotation order.";
+            };
+          };
+        };
+        default = {};
+        description = "Quadrant-to-app mapping for the Nix-native layout.";
+      };
+    };
+  };
+
+  mapApp = app:
+    {
+      app = null;
+      name = app.name;
+      animate = app.animate;
+    }
+    // optionalAttrs (app.duration != null) { duration = app.duration; }
+    // optionalAttrs (app.scope != null) { scope = app.scope; }
+    // optionalAttrs app.persistentDraw { "persistent-draw" = true; }
+    // optionalAttrs (app.disposeFn != null) { "dispose-fn" = app.disposeFn; }
+    // optionalAttrs (!app.display) { display = false; }
+    // optionalAttrs (app.args != {}) { args = app.args; };
+
+  layoutAsSettings =
+    if cfg.layout == null then null
+    else {
+      duration = cfg.layout.duration;
+      quadrants = {
+        top-left = map mapApp cfg.layout.quadrants.topLeft;
+        bottom-left = map mapApp cfg.layout.quadrants.bottomLeft;
+        top-right = map mapApp cfg.layout.quadrants.topRight;
+        bottom-right = map mapApp cfg.layout.quadrants.bottomRight;
+      };
+    };
+
+  legacyOptionsUsed = any (value: value != null) [
+    cfg.topLeft
+    cfg.bottomLeft
+    cfg.topRight
+    cfg.bottomRight
+  ];
+
+  inlineSettings =
+    if cfg.layout != null then layoutAsSettings
+    else if cfg.settings != null then cfg.settings
+    else cfg.config;
+
+  legacySettings = {
+    duration = cfg.legacyDuration;
+    quadrants = {
+      top-left = [{
+        app = null;
+        name = cfg.topLeft;
+        duration = cfg.legacyDuration;
+        animate = false;
+      }];
+      top-right = [{
+        app = null;
+        name = cfg.topRight;
+        duration = cfg.legacyDuration;
+        animate = false;
+      }];
+      bottom-left = [{
+        app = null;
+        name = cfg.bottomLeft;
+        duration = cfg.legacyDuration;
+        animate = false;
+      }];
+      bottom-right = [{
+        app = null;
+        name = cfg.bottomRight;
+        duration = cfg.legacyDuration;
+        animate = false;
+      }];
+    };
+  };
+
+  managedConfigFile =
+    if cfg.configFile != null then cfg.configFile
+    else if inlineSettings != null then yamlFormat.generate "led-matrix-config.yaml" inlineSettings
+    else if legacyOptionsUsed then yamlFormat.generate "led-matrix-config.yaml" legacySettings
+    else null;
+
+  resolvedConfigFile =
+    if cfg.configurationMode == "linuxOS" then null
+    else managedConfigFile;
+
+  layoutQuadrantsNonEmpty =
+    if cfg.layout == null then true
+    else all (apps: apps != []) [
+      cfg.layout.quadrants.topLeft
+      cfg.layout.quadrants.bottomLeft
+      cfg.layout.quadrants.topRight
+      cfg.layout.quadrants.bottomRight
+    ];
+
+  serviceArgs =
+    optionals (resolvedConfigFile != null) [ "--config-file" (toString resolvedConfigFile) ]
+    ++ optionals cfg.disableKeyListener [ "--no-key-listener" ]
+    ++ optionals cfg.disablePlugins [ "--disable-plugins" ]
+    ++ cfg.extraArguments;
+
+  serviceCommand = escapeShellArgs ([ "${cfg.package}/bin/led-matrix-monitor" ] ++ serviceArgs);
+in
+{
+  options.services.led-matrix-monitoring = {
+    enable = mkEnableOption "Framework LED Matrix system monitoring service";
+
+    configurationMode = mkOption {
+      type = types.enum [ "linuxOS" "nix-flake" "nix-module" ];
+      default = "nix-module";
+      description = ''
+        Selects how the service resolves configuration:
+        - `linuxOS`: do not provide Nix-managed config; the app uses its built-in Linux config lookup.
+        - `nix-flake`: use Nix-managed config generated/provided through module options.
+        - `nix-module`: same config behavior as `nix-flake`, intended for direct module-driven setup.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.callPackage ./default.nix {};
+      defaultText = literalExpression "pkgs.callPackage ./default.nix {}";
+      description = ''
+        Package providing the `led-matrix-monitor` executable.
+      '';
+    };
+
+    layout = mkOption {
+      type = types.nullOr layoutType;
+      default = null;
+      description = ''
+        Nix-native service layout schema.
+        This is the recommended configuration style for NixOS users because it keeps
+        all app and quadrant definitions in module options and generates runtime config automatically.
+      '';
+      example = literalExpression ''
+        {
+          duration = 10;
+          quadrants = {
+            topLeft = [{ name = "cpu"; }];
+            bottomLeft = [{ name = "mem-bat"; }];
+            topRight = [{ name = "disk"; }];
+            bottomRight = [{ name = "net"; }];
+          };
+        }
+      '';
+    };
+
+    settings = mkOption {
+      type = types.nullOr yamlFormat.type;
+      default = null;
+      description = ''
+        Raw settings as a Nix attrset rendered to YAML.
+        This is kept for compatibility; prefer `layout`.
+        Mutually exclusive with `configFile`.
+      '';
+    };
+
+    config = mkOption {
+      type = types.nullOr yamlFormat.type;
+      default = null;
+      description = ''
+        Deprecated alias for `settings`.
+      '';
+    };
+
+    configFile = mkOption {
+      type = types.nullOr (types.oneOf [ types.path types.str ]);
+      default = null;
+      description = ''
+        Path to an existing YAML configuration file to pass to `--config-file`.
+        Mutually exclusive with `layout`, `settings`, `config`, and legacy quadrant options.
+      '';
+      example = "/etc/led-matrix/config.yaml";
+    };
+
+    topLeft = mkOption {
+      type = types.nullOr legacyMetricType;
+      default = null;
+      description = ''
+        Deprecated legacy shorthand for top-left quadrant app.
+        Use `layout` or `configFile` instead.
+      '';
+    };
+
+    bottomLeft = mkOption {
+      type = types.nullOr legacyMetricType;
+      default = null;
+      description = ''
+        Deprecated legacy shorthand for bottom-left quadrant app.
+        Use `layout` or `configFile` instead.
+      '';
+    };
+
+    topRight = mkOption {
+      type = types.nullOr legacyMetricType;
+      default = null;
+      description = ''
+        Deprecated legacy shorthand for top-right quadrant app.
+        Use `layout` or `configFile` instead.
+      '';
+    };
+
+    bottomRight = mkOption {
+      type = types.nullOr legacyMetricType;
+      default = null;
+      description = ''
+        Deprecated legacy shorthand for bottom-right quadrant app.
+        Use `layout` or `configFile` instead.
+      '';
+    };
+
+    legacyDuration = mkOption {
+      type = types.ints.positive;
+      default = 10;
+      description = ''
+        Duration (in seconds) used when generating config from legacy quadrant options.
+      '';
+    };
+
+    disableKeyListener = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Disable keyboard shortcut listener.";
+    };
+
+    disablePlugins = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Disable loading plugin apps.";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "root";
+      description = "User account to run the service as.";
+    };
+
+    group = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Primary group for the service user.
+        Defaults to `root` when `user = "root"`, otherwise `users`.
+      '';
+    };
+
+    environment = mkOption {
+      type = types.attrsOf types.str;
+      default = {};
+      description = ''
+        Additional environment variables passed to the systemd service.
+      '';
+      example = {
+        DISPLAY = ":0";
+      };
+    };
+
+    extraArguments = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = ''
+        Additional CLI arguments appended to the service command.
+      '';
+      example = [ "--list-apps" ];
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.settings == null || cfg.config == null;
+        message = "services.led-matrix-monitoring: `settings` and deprecated `config` cannot both be set.";
+      }
+      {
+        assertion = cfg.layout == null || (cfg.settings == null && cfg.config == null && cfg.configFile == null && !legacyOptionsUsed);
+        message = "services.led-matrix-monitoring: `layout` is mutually exclusive with `settings`, `config`, `configFile`, and legacy quadrant options.";
+      }
+      {
+        assertion = cfg.configFile == null || (cfg.layout == null && cfg.settings == null && cfg.config == null && !legacyOptionsUsed);
+        message = "services.led-matrix-monitoring: `configFile` is mutually exclusive with `layout`, `settings`, `config`, and legacy quadrant options.";
+      }
+      {
+        assertion = !legacyOptionsUsed || all (value: value != null) [ cfg.topLeft cfg.bottomLeft cfg.topRight cfg.bottomRight ];
+        message = "services.led-matrix-monitoring: when using legacy quadrant options, all four of topLeft/bottomLeft/topRight/bottomRight must be set.";
+      }
+      {
+        assertion = layoutQuadrantsNonEmpty;
+        message = "services.led-matrix-monitoring: each `layout.quadrants` entry must contain at least one app.";
+      }
+      {
+        assertion = cfg.configurationMode != "linuxOS" || managedConfigFile == null;
+        message = "services.led-matrix-monitoring: `configurationMode = \"linuxOS\"` cannot be combined with `layout`, `settings`, `config`, `configFile`, or legacy quadrant options.";
+      }
+      {
+        assertion = cfg.configurationMode == "linuxOS" || managedConfigFile != null;
+        message = "services.led-matrix-monitoring: for `nix-flake`/`nix-module`, set one configuration source (`layout`, `settings`, `config`, `configFile`, or all legacy quadrant options).";
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.led-matrix-monitoring = {
+      description = "Framework LED Matrix System Monitor";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      environment = cfg.environment
+        // optionalAttrs (resolvedConfigFile != null) { CONFIG_FILE = toString resolvedConfigFile; }
+        // {
+          LED_MATRIX_CONFIGURATION_MODE = cfg.configurationMode;
+        };
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group =
+          if cfg.group != null then cfg.group
+          else if cfg.user == "root" then "root"
+          else "users";
+        SupplementaryGroups = optionals (!cfg.disableKeyListener && cfg.user != "root") [ "input" ];
+        Restart = "always";
+        RestartSec = "10s";
+      };
+
+      script = ''
+        exec ${serviceCommand}
+      '';
+    };
+  };
+}

--- a/ledmatrixmonitoring.nix
+++ b/ledmatrixmonitoring.nix
@@ -30,7 +30,11 @@ let
       scope = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = "Optional app scope (for example `panel`).";
+        description = ''
+          Optional app scope (for example `panel`).
+          When set to `panel`, the active app owns the full panel and the sibling quadrant on that side is suppressed by the scheduler while it is active.
+          If both top and bottom apps on a panel simultaneously request `scope = "panel"`, top quadrant takes precedence and a warning is logged.
+        '';
       };
 
       persistentDraw = mkOption {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "framework-led-matrix-monitor"
-version = "1.1.1"
+version = "2.1.2"
 description = "System monitor application for Framework 16 LED matrix modules"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/module-test-configuration.nix
+++ b/tests/module-test-configuration.nix
@@ -1,0 +1,22 @@
+{ ... }:
+
+{
+  services.led-matrix-monitoring = {
+    enable = true;
+    configurationMode = "nix-module";
+
+    layout = {
+      duration = 10;
+      quadrants = {
+        topLeft = [{ name = "cpu"; }];
+        bottomLeft = [{ name = "mem-bat"; }];
+        topRight = [{ name = "disk"; }];
+        bottomRight = [{ name = "net"; }];
+      };
+    };
+
+    disableKeyListener = true;
+    disablePlugins = false;
+    user = "root";
+  };
+}


### PR DESCRIPTION
## Summary
- enforce scheduler ownership for `scope: panel` apps so sibling quadrants are suppressed for rendering and rotation
- keep top-quadrant precedence when both apps on a panel request panel scope, with conflict warning behavior
- add weather provider fallback flow (OpenWeather primary when key exists, Open-Meteo fallback when unavailable/failing)
- expand NixOS module/docs coverage for configuration modes, option compatibility, and layout/app option semantics

## Validation
- python compile checks on updated monitor/weather modules
- nix build for package output
- nix flake checks
- runtime verification on active service and LED serial write path
- linuxOS module-mode evaluation: confirms `CONFIG_FILE` is not injected and managed config sources are rejected in linuxOS mode