### PR TITLE
Harden service installer defaults across Linux distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ For automated continuous execution, you can run as a systemd service instead:
 # The service runs as a user-level systemd service under the logged in user's account
 ./build_and_install.sh
 # manage the service
-systemctl --user start|stop|status fwledmatrix.service
+systemctl --user start|stop|status fwledmonitor.service
 # The service config file is at ~/.config/systemd/user/fwledmonitor.service.
 # The service executable is at /opt/led_mon/led_mon (sym-linked to /usr/local/bin/led_mon)
 ```

--- a/install_service.sh
+++ b/install_service.sh
@@ -5,6 +5,7 @@ xauthority=$XAUTHORITY
 wayland_display=${WAYLAND_DISPLAY:-wayland-1}
 
 sudo rm -f /etc/systemd/system/fwledmonitor.service
+mkdir -p "$HOME/.config/systemd/user"
 sudo tee $HOME/.config/systemd/user/fwledmonitor.service > /dev/null <<EOF
 [Unit]
 Description=Framework 16 LED System Monitor
@@ -27,7 +28,18 @@ WantedBy=default.target
 EOF
 
 if ! id -u "led_mon" &>/dev/null 2>&1; then
-    sudo useradd   --system   --home /var/lib/led_mon  -G input,dialout --shell /usr/sbin/nologin   led_mon
+    groups_to_add=()
+    for group in input dialout; do
+        if getent group "$group" >/dev/null 2>&1; then
+            groups_to_add+=("$group")
+        fi
+    done
+
+    useradd_args=(--system --home /var/lib/led_mon --shell /usr/sbin/nologin)
+    if [[ ${#groups_to_add[@]} -gt 0 ]]; then
+        useradd_args+=( -G "$(IFS=,; echo "${groups_to_add[*]}")" )
+    fi
+    sudo useradd "${useradd_args[@]}" led_mon
 fi
 sudo mkdir -p /var/lib/led_mon/.config
 sudo chown led_mon:led_mon /var/lib/led_mon/.config
@@ -36,7 +48,13 @@ sudo chmod 777 /var/lib/led_mon/.config
 sudo mkdir -p /etc/led_mon
 sudo chown -R root /etc/led_mon
 # Copy .env-example to .env and set API Key env variables
-sudo cp .env /etc/led_mon/led_mon.env
+if [[ -f .env ]]; then
+    sudo cp .env /etc/led_mon/led_mon.env
+elif [[ -f .env-example ]]; then
+    sudo cp .env-example /etc/led_mon/led_mon.env
+else
+    sudo touch /etc/led_mon/led_mon.env
+fi
 # PyInsatller does not include config-local.yaml with --add-data because it may not exist
 if [[ -f led_mon/config-local.yaml ]];then
     cp led_mon/config-local.yaml ./dist/led_mon/_internal/led_mon/config-local.yaml


### PR DESCRIPTION
## What this PR fixes
- makes `install_service.sh` resilient when `input`/`dialout` groups are absent by adding only existing groups to `useradd`
- ensures `~/.config/systemd/user` exists before writing the user service unit
- falls back to `.env-example` (or creates an empty env file) when `.env` is missing
- fixes README service command typo from `fwledmatrix.service` to `fwledmonitor.service`

## Root cause and rationale
Installer failures were being hit on some distro variants because setup made assumptions that are not always true:
- `input`/`dialout` groups are always present
- `.env` is always present
- user systemd unit directory already exists

There was also a README service-name mismatch that pointed users to `fwledmatrix.service` while the installer creates `fwledmonitor.service`.

This PR hardens installer defaults without changing normal behavior on systems where these assumptions already hold.

## Validation
- `bash -n install_service.sh`

## Related branch (runtime reconnect issue)
- `fix/drawing-thread-reconnect` (separated as requested)
